### PR TITLE
[#94] Converting ED25519 to X25519 for KeyAgreement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@lto-network/lto-crypto": "^1.1.0",
+        "@lto-network/lto-crypto": "^1.1.1",
         "@nestjs/common": "^7.6.0",
         "@nestjs/core": "^7.6.0",
         "@nestjs/passport": "^7.1.0",
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/@lto-network/lto-crypto": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lto-network/lto-crypto/-/lto-crypto-1.1.0.tgz",
-      "integrity": "sha512-cB/7VeFg/lMqwaH3zA/yVc+zP5++HL1/dI+o8Mrfh2cS009mHoDxM0i74Vy0iGtsls5KRClOHFps3qreILE5kA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lto-network/lto-crypto/-/lto-crypto-1.1.1.tgz",
+      "integrity": "sha512-YA6ATCP+RfWN/0Tvb6CZKs2meUAUAf3cvEVa5tpNNkJjhozxloAONxPP/9DxhUjkmiqWU6fy8xPD2eCYv3lvmQ==",
       "dependencies": {
         "@types/crypto-js": "^3.1.43",
         "crypto-js": "^3.1.9-1",
@@ -17661,9 +17661,9 @@
       }
     },
     "@lto-network/lto-crypto": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lto-network/lto-crypto/-/lto-crypto-1.1.0.tgz",
-      "integrity": "sha512-cB/7VeFg/lMqwaH3zA/yVc+zP5++HL1/dI+o8Mrfh2cS009mHoDxM0i74Vy0iGtsls5KRClOHFps3qreILE5kA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lto-network/lto-crypto/-/lto-crypto-1.1.1.tgz",
+      "integrity": "sha512-YA6ATCP+RfWN/0Tvb6CZKs2meUAUAf3cvEVa5tpNNkJjhozxloAONxPP/9DxhUjkmiqWU6fy8xPD2eCYv3lvmQ==",
       "requires": {
         "@types/crypto-js": "^3.1.43",
         "crypto-js": "^3.1.9-1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@lto-network/lto-crypto": "^1.1.0",
+    "@lto-network/lto-crypto": "^1.1.1",
     "@nestjs/common": "^7.6.0",
     "@nestjs/core": "^7.6.0",
     "@nestjs/passport": "^7.1.0",

--- a/src/identity/identity.service.spec.ts
+++ b/src/identity/identity.service.spec.ts
@@ -11,20 +11,24 @@ describe('IdentityService', () => {
   let identityService: IdentityService;
   let verificationMethodService: VerificationMethodService;
 
-  const publicKey = '6wx5nshSAkF7GEgxZRet86XnqSog3k3DzkyCaBKStiUd';
   const sender = {
     chainId: 'T',
     address: '3N6mZMgGqYn9EVAR2Vbf637iej4fFipECq8',
+    ed25519PublicKey: '6wx5nshSAkF7GEgxZRet86XnqSog3k3DzkyCaBKStiUd',
   };
 
   const recipient = {
     chainId: 'T',
     address: '3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ',
+    ed25519PublicKey: '6YQpeq9Yeh3VDAuVQvnUQLcUTnEq9hPUwCb9nX3yZHPC',
+    x25519PublicKey: '37CFMfB3MU1tzJKNVadeZiGytUH6HFLDNNeJETzY7N8o',
   };
 
   const secondRecipient = {
     chainId: 'T',
     address: '3N2kNjWiCMuTgdGcLzx8uHiwBKY2J7Sd3t4',
+    ed25519PublicKey: 'DeAxCdh1pYXpU7h41ieyqTDrTyQmhJWZarqxTtkmJv99',
+    x25519PublicKey: 'E6C6H2pfFvjwxELHK63kcekh2ADhFM2Zt5wqKkStSAxX',
   };
 
   function spy() {
@@ -33,7 +37,13 @@ describe('IdentityService', () => {
     };
 
     const storage = {
-      getPublicKey: jest.spyOn(storageService, 'getPublicKey').mockImplementation(async () => publicKey),
+      getPublicKey: jest.spyOn(storageService, 'getPublicKey').mockImplementation(async (address: string) => {
+        if (address === sender.address) return sender.ed25519PublicKey;
+        if (address === recipient.address) return recipient.ed25519PublicKey;
+        if (address === secondRecipient.address) return secondRecipient.ed25519PublicKey;
+
+        return null;
+      }),
     };
 
     return { verificationMethod, storage };
@@ -65,7 +75,7 @@ describe('IdentityService', () => {
           id: `did:lto:${sender.address}#key`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${sender.address}`,
-          publicKeyBase58: publicKey,
+          publicKeyBase58: sender.ed25519PublicKey,
           blockchainAccountId: `${sender.address}@lto:${sender.chainId}`,
         }],
         authentication: [
@@ -94,7 +104,7 @@ describe('IdentityService', () => {
 
       const did = await identityService.resolve(sender.address);
 
-      expect(spies.storage.getPublicKey.mock.calls.length).toBe(1);
+      expect(spies.storage.getPublicKey.mock.calls.length).toBe(2);
       expect(spies.verificationMethod.getMethodsFor.mock.calls.length).toBe(1);
 
       expect(did).toEqual({
@@ -104,13 +114,13 @@ describe('IdentityService', () => {
           id: `did:lto:${sender.address}#key`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${sender.address}`,
-          publicKeyBase58: publicKey,
+          publicKeyBase58: sender.ed25519PublicKey,
           blockchainAccountId: `${sender.address}@lto:${sender.chainId}`,
         }, {
           id: `did:lto:${recipient.address}#key`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${recipient.address}`,
-          publicKeyBase58: publicKey,
+          publicKeyBase58: recipient.ed25519PublicKey,
           blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
         }],
         authentication: [
@@ -119,9 +129,13 @@ describe('IdentityService', () => {
         assertionMethod: [
           `did:lto:${recipient.address}#key`,
         ],
-        keyAgreement: [
-          `did:lto:${recipient.address}#key`,
-        ],
+        keyAgreement: [{
+          id: `did:lto:${recipient.address}#sign`,
+          type: 'X25519KeyAgreementKey2019',
+          controller: `did:lto:${recipient.address}`,
+          publicKeyBase58: recipient.x25519PublicKey,
+          blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
+        }],
       });
     });
 
@@ -130,14 +144,14 @@ describe('IdentityService', () => {
 
       spies.verificationMethod.getMethodsFor = jest.spyOn(verificationMethodService, 'getMethodsFor').mockImplementation(async (address: string) => {
         const relationships = 0x0107; // authentication, assertion, key agreement
-        const secondRelationships = 0x0113; // authentication, assertion, capabilityDelegation
+        const secondRelationships = 0x0115; // authentication, assertion, key agreement, capability delegation
 
         return [new VerificationMethod(relationships, address, recipient.address, 123456), new VerificationMethod(secondRelationships, address, secondRecipient.address, 123456)];
       });
 
       const did = await identityService.resolve(sender.address);
 
-      expect(spies.storage.getPublicKey.mock.calls.length).toBe(1);
+      expect(spies.storage.getPublicKey.mock.calls.length).toBe(3);
       expect(spies.verificationMethod.getMethodsFor.mock.calls.length).toBe(1);
 
       expect(did).toEqual({
@@ -147,19 +161,19 @@ describe('IdentityService', () => {
           id: `did:lto:${sender.address}#key`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${sender.address}`,
-          publicKeyBase58: publicKey,
+          publicKeyBase58: sender.ed25519PublicKey,
           blockchainAccountId: `${sender.address}@lto:${sender.chainId}`,
         }, {
           id: `did:lto:${recipient.address}#key`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${recipient.address}`,
-          publicKeyBase58: publicKey,
+          publicKeyBase58: recipient.ed25519PublicKey,
           blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
         }, {
           id: `did:lto:${secondRecipient.address}#key`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${secondRecipient.address}`,
-          publicKeyBase58: publicKey,
+          publicKeyBase58: secondRecipient.ed25519PublicKey,
           blockchainAccountId: `${secondRecipient.address}@lto:${secondRecipient.chainId}`,
         }],
         authentication: [
@@ -170,9 +184,19 @@ describe('IdentityService', () => {
           `did:lto:${recipient.address}#key`,
           `did:lto:${secondRecipient.address}#key`,
         ],
-        keyAgreement: [
-          `did:lto:${recipient.address}#key`,
-        ],
+        keyAgreement: [{
+          id: `did:lto:${recipient.address}#sign`,
+          type: 'X25519KeyAgreementKey2019',
+          controller: `did:lto:${recipient.address}`,
+          publicKeyBase58: recipient.x25519PublicKey,
+          blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
+        }, {
+          id: `did:lto:${secondRecipient.address}#sign`,
+          type: 'X25519KeyAgreementKey2019',
+          controller: `did:lto:${secondRecipient.address}`,
+          publicKeyBase58: secondRecipient.x25519PublicKey,
+          blockchainAccountId: `${secondRecipient.address}@lto:${secondRecipient.chainId}`,
+        }],
         capabilityDelegation: [
           `did:lto:${secondRecipient.address}#key`,
         ]

--- a/src/identity/identity.service.spec.ts
+++ b/src/identity/identity.service.spec.ts
@@ -72,20 +72,20 @@ describe('IdentityService', () => {
         '@context': 'https://www.w3.org/ns/did/v1',
         id: `did:lto:${sender.address}`,
         verificationMethod: [{
-          id: `did:lto:${sender.address}#key`,
+          id: `did:lto:${sender.address}#sign`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${sender.address}`,
           publicKeyBase58: sender.ed25519PublicKey,
           blockchainAccountId: `${sender.address}@lto:${sender.chainId}`,
         }],
         authentication: [
-          `did:lto:${sender.address}#key`,
+          `did:lto:${sender.address}#sign`,
         ],
         assertionMethod: [
-          `did:lto:${sender.address}#key`,
+          `did:lto:${sender.address}#sign`,
         ],
         capabilityInvocation: [
-          `did:lto:${sender.address}#key`,
+          `did:lto:${sender.address}#sign`,
         ]
       });
 
@@ -111,26 +111,26 @@ describe('IdentityService', () => {
         '@context': 'https://www.w3.org/ns/did/v1',
         id: `did:lto:${sender.address}`,
         verificationMethod: [{
-          id: `did:lto:${sender.address}#key`,
+          id: `did:lto:${sender.address}#sign`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${sender.address}`,
           publicKeyBase58: sender.ed25519PublicKey,
           blockchainAccountId: `${sender.address}@lto:${sender.chainId}`,
         }, {
-          id: `did:lto:${recipient.address}#key`,
+          id: `did:lto:${recipient.address}#sign`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${recipient.address}`,
           publicKeyBase58: recipient.ed25519PublicKey,
           blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
         }],
         authentication: [
-          `did:lto:${recipient.address}#key`,
+          `did:lto:${recipient.address}#sign`,
         ],
         assertionMethod: [
-          `did:lto:${recipient.address}#key`,
+          `did:lto:${recipient.address}#sign`,
         ],
         keyAgreement: [{
-          id: `did:lto:${recipient.address}#sign`,
+          id: `did:lto:${recipient.address}#encrypt`,
           type: 'X25519KeyAgreementKey2019',
           controller: `did:lto:${recipient.address}`,
           publicKeyBase58: recipient.x25519PublicKey,
@@ -158,47 +158,47 @@ describe('IdentityService', () => {
         '@context': 'https://www.w3.org/ns/did/v1',
         id: `did:lto:${sender.address}`,
         verificationMethod: [{
-          id: `did:lto:${sender.address}#key`,
+          id: `did:lto:${sender.address}#sign`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${sender.address}`,
           publicKeyBase58: sender.ed25519PublicKey,
           blockchainAccountId: `${sender.address}@lto:${sender.chainId}`,
         }, {
-          id: `did:lto:${recipient.address}#key`,
+          id: `did:lto:${recipient.address}#sign`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${recipient.address}`,
           publicKeyBase58: recipient.ed25519PublicKey,
           blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
         }, {
-          id: `did:lto:${secondRecipient.address}#key`,
+          id: `did:lto:${secondRecipient.address}#sign`,
           type: 'Ed25519VerificationKey2018',
           controller: `did:lto:${secondRecipient.address}`,
           publicKeyBase58: secondRecipient.ed25519PublicKey,
           blockchainAccountId: `${secondRecipient.address}@lto:${secondRecipient.chainId}`,
         }],
         authentication: [
-          `did:lto:${recipient.address}#key`,
-          `did:lto:${secondRecipient.address}#key`,
+          `did:lto:${recipient.address}#sign`,
+          `did:lto:${secondRecipient.address}#sign`,
         ],
         assertionMethod: [
-          `did:lto:${recipient.address}#key`,
-          `did:lto:${secondRecipient.address}#key`,
+          `did:lto:${recipient.address}#sign`,
+          `did:lto:${secondRecipient.address}#sign`,
         ],
         keyAgreement: [{
-          id: `did:lto:${recipient.address}#sign`,
+          id: `did:lto:${recipient.address}#encrypt`,
           type: 'X25519KeyAgreementKey2019',
           controller: `did:lto:${recipient.address}`,
           publicKeyBase58: recipient.x25519PublicKey,
           blockchainAccountId: `${recipient.address}@lto:${recipient.chainId}`,
         }, {
-          id: `did:lto:${secondRecipient.address}#sign`,
+          id: `did:lto:${secondRecipient.address}#encrypt`,
           type: 'X25519KeyAgreementKey2019',
           controller: `did:lto:${secondRecipient.address}`,
           publicKeyBase58: secondRecipient.x25519PublicKey,
           blockchainAccountId: `${secondRecipient.address}@lto:${secondRecipient.chainId}`,
         }],
         capabilityDelegation: [
-          `did:lto:${secondRecipient.address}#key`,
+          `did:lto:${secondRecipient.address}#sign`,
         ]
       });
     });

--- a/src/identity/identity.service.ts
+++ b/src/identity/identity.service.ts
@@ -54,7 +54,7 @@ export class IdentityService {
       '@context': 'https://www.w3.org/ns/did/v1',
       id: `did:lto:${id}`,
       verificationMethod: [{
-        id: `did:lto:${address}#key`,
+        id: `did:lto:${address}#sign`,
         type: 'Ed25519VerificationKey2018',
         controller: `did:lto:${address}`,
         publicKeyBase58: publicKey,
@@ -84,7 +84,7 @@ export class IdentityService {
 
       if (verificationMethod.isKeyAgreement()) {
         const keyAgreement = {
-          id: `${didVerificationMethod.controller}#sign`,
+          id: `${didVerificationMethod.controller}#encrypt`,
           type: 'X25519KeyAgreementKey2019',
           controller: didVerificationMethod.controller,
           publicKeyBase58: convertED2KeyToX2(recipientPublicKey),
@@ -110,9 +110,9 @@ export class IdentityService {
     }
 
     if (didDocument.verificationMethod.length == 1) {
-      didDocument.authentication = [ `did:lto:${address}#key` ];
-      didDocument.assertionMethod = [ `did:lto:${address}#key` ];
-      didDocument.capabilityInvocation = [ `did:lto:${address}#key` ];
+      didDocument.authentication = [ `did:lto:${address}#sign` ];
+      didDocument.assertionMethod = [ `did:lto:${address}#sign` ];
+      didDocument.capabilityInvocation = [ `did:lto:${address}#sign` ];
     }
 
     return didDocument;

--- a/src/identity/interfaces/identity.interface.ts
+++ b/src/identity/interfaces/identity.interface.ts
@@ -12,7 +12,7 @@ export interface DIDDocument {
   verificationMethod: DIDVerificationMethod[];
   authentication?: string[];
   assertionMethod?: string[];
-  keyAgreement?: string[];
+  keyAgreement?: DIDVerificationMethod[];
   capabilityInvocation?: string[];
   capabilityDelegation?: string[];
 };

--- a/src/verification-method/model/verification-method.model.ts
+++ b/src/verification-method/model/verification-method.model.ts
@@ -45,7 +45,7 @@ export class VerificationMethod {
 
     public asDidMethod(publicKey: string): DIDVerificationMethod {
         return {
-            id: `did:lto:${this.recipient}#key`,
+            id: `did:lto:${this.recipient}#sign`,
             type: 'Ed25519VerificationKey2018',
             controller: `did:lto:${this.recipient}`,
             publicKeyBase58: publicKey,

--- a/src/verification-method/model/verification-method.model.ts
+++ b/src/verification-method/model/verification-method.model.ts
@@ -12,11 +12,10 @@ export interface MethodObject {
 
 export class VerificationMethod {
     public sender: string;
+    public recipient: string;
     public createdAt?: number;
     public revokedAt?: number;
-
     private relationships: number;
-    private recipient: string;
 
     constructor(relationships: number, sender: string, recipient: string, createdAt: number, revokedAt?: number) {
         this.sender = sender;


### PR DESCRIPTION
- Updates `@lto-network/lto-crypto` to version `1.1.1`
  - This version includes `convertED2KeyToX2` function needed for this task
- Changes the way `keyAgreement` associations are generated when resolving a DID
  - Adds the entire object instead of just a reference
  - Converts a `ED25519` key to `X25519` key
- Fixes a behaviour where the same public key was being used for all associations
  - Correct behaviour is to get the `recipient` public key for the associations, using `sender` public key only for the "initial/original" verification method

---

closes #94   