### PR TITLE
[#99] Config for anchor indexing

### DIFF
--- a/src/anchor/anchor.service.ts
+++ b/src/anchor/anchor.service.ts
@@ -26,7 +26,7 @@ export class AnchorService {
 
     const anchorIndexing = this.config.getAnchorIndexing();
     const senderRoles = await this.storage.getRolesFor(sender);
-    const isSenderTrustNetwork = Object.keys(senderRoles).length === 0;
+    const isSenderTrustNetwork = Object.keys(senderRoles).length > 0;
 
     if (anchorIndexing === 'none') {
       return;
@@ -36,7 +36,7 @@ export class AnchorService {
       return;
     }
 
-    if (anchorIndexing === 'trust' && isSenderTrustNetwork) {
+    if (anchorIndexing === 'trust' && !isSenderTrustNetwork) {
       return;
     }
 
@@ -57,7 +57,7 @@ export class AnchorService {
         }
       }
     } else if (transaction.type === 15 && !!transaction.anchors) {
-      transaction.anchors.forEach(async anchor => {
+      for (const anchor of transaction.anchors) {
         const hexHash = this.encoder.hexEncode(
           this.encoder.base58Decode(anchor),
         );
@@ -67,7 +67,7 @@ export class AnchorService {
           blockHeight,
           position,
         });
-      });
+      }
     }
   }
 }

--- a/src/anchor/anchor.service.ts
+++ b/src/anchor/anchor.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { LoggerService } from '../logger/logger.service';
-import delay from 'delay';
 import { IndexDocumentType } from '../index/model/index.model';
 import { EncoderService } from '../encoder/encoder.service';
 import { StorageService } from '../storage/storage.service';
+import { ConfigService } from '../config/config.service';
 
 @Injectable()
 export class AnchorService {
@@ -14,6 +14,7 @@ export class AnchorService {
     private readonly logger: LoggerService,
     private readonly encoder: EncoderService,
     private readonly storage: StorageService,
+    private readonly config: ConfigService,
   ) {
     this.transactionTypes = [12, 15];
     this.anchorToken = '\u2693';
@@ -21,8 +22,21 @@ export class AnchorService {
 
   async index(index: IndexDocumentType) {
     const { transaction, blockHeight, position } = index;
+    const { sender } = transaction;
+
+    const anchorIndexing = this.config.getAnchorIndexing();
+    const senderRoles = await this.storage.getRolesFor(sender);
+    const isSenderTrustNetwork = Object.keys(senderRoles).length === 0;
+
+    if (anchorIndexing === 'none') {
+      return;
+    }
 
     if (this.transactionTypes.indexOf(transaction.type) === -1) {
+      return;
+    }
+
+    if (anchorIndexing === 'trust' && isSenderTrustNetwork) {
       return;
     }
 

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -136,4 +136,8 @@ export class ConfigService {
   getRoles(): RoleConfig {
     return this.config.get('roles');
   }
+
+  getAnchorIndexing(): 'none' | 'trust' | 'all' {
+    return this.config.get('anchor_indexing');
+  }
 }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -138,6 +138,6 @@ export class ConfigService {
   }
 
   getAnchorIndexing(): 'none' | 'trust' | 'all' {
-    return this.config.get('anchor.node.indexing');
+    return this.config.get('anchor.indexing');
   }
 }

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -138,6 +138,6 @@ export class ConfigService {
   }
 
   getAnchorIndexing(): 'none' | 'trust' | 'all' {
-    return this.config.get('anchor_indexing');
+    return this.config.get('anchor.node.indexing');
   }
 }

--- a/src/config/data/default.schema.json
+++ b/src/config/data/default.schema.json
@@ -82,6 +82,11 @@
       },
       "starting_block": 1,
       "restart_sync": false,
+      "anchor_indexing": {
+        "default": "all",
+        "format": ["none", "trust", "all"],
+        "env": "ANCHOR_INDEXING"
+      },
       "anchor_fee": {
         "default": 35000000,
         "env": "ANCHOR_NODE_ANCHOR_FEE"

--- a/src/config/data/default.schema.json
+++ b/src/config/data/default.schema.json
@@ -82,7 +82,7 @@
       },
       "starting_block": 1,
       "restart_sync": false,
-      "anchor_indexing": {
+      "indexing": {
         "default": "all",
         "format": ["none", "trust", "all"],
         "env": "ANCHOR_INDEXING"

--- a/src/config/data/default.schema.json
+++ b/src/config/data/default.schema.json
@@ -75,6 +75,11 @@
       "default": "lto-index",
       "env": "ANCHOR_LEVELDB"
     },
+    "indexing": {
+      "default": "all",
+      "format": ["none", "trust", "all"],
+      "env": "ANCHOR_INDEXING"
+    },
     "node": {
       "url": {
         "default": "",
@@ -82,11 +87,6 @@
       },
       "starting_block": 1,
       "restart_sync": false,
-      "indexing": {
-        "default": "all",
-        "format": ["none", "trust", "all"],
-        "env": "ANCHOR_INDEXING"
-      },
       "anchor_fee": {
         "default": 35000000,
         "env": "ANCHOR_NODE_ANCHOR_FEE"

--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -1,5 +1,10 @@
 {
+  "lto": {
+    "node": {
+      "url": "http://testnet.lto.network"
+    }
+  },
   "log": {
-    "level": "info"
+    "level": "debug"
   }
 }


### PR DESCRIPTION
- Adds configuration for choosing which anchor transactions to index
  - `none`, `trust` or `all`
    - If `none`, will not index any anchors
    - If `trust`, will only index anchors from addresses in the trust network
    - If `all`, will index all anchors

---

closes #99 