### PR TITLE
Remove reference to _public folder from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ FROM node:dubnium-alpine
 # Move the build files from build folder to app folder
 WORKDIR /usr/app
 COPY --from=build /usr/src/dist ./
-COPY --from=build /usr/src/_public /usr/_public/
 COPY --from=build /usr/src/node_modules ./node_modules/
 
 ADD package.json ./


### PR DESCRIPTION
 as it was removed in https://github.com/ltonetwork/indexer/commit/e349f2cc21a4cddbb14782fcc8a011e81418b288

Docker build currently fails because of it.