### PR TITLE
Fixing anchor and association indexing for trust network

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "printWidth": 120
 }

--- a/src/anchor/anchor.module.ts
+++ b/src/anchor/anchor.module.ts
@@ -10,6 +10,7 @@ import { EncoderModule } from '../encoder/encoder.module';
 import { TransactionModule } from '../transaction/transaction.module';
 import { AnchorListenerService } from './anchor-listener.service';
 import { EmitterModule } from '../emitter/emitter.module';
+import { TrustNetworkModule } from '../trust-network/trust-network.module';
 
 export const AnchorModuleConfig = {
   imports: [
@@ -20,19 +21,13 @@ export const AnchorModuleConfig = {
     RedisModule,
     StorageModule,
     TransactionModule,
+    TrustNetworkModule,
     EmitterModule,
   ],
   controllers: [],
-  providers: [
-    ...anchorProviders,
-    AnchorService,
-    AnchorListenerService,
-  ],
-  exports: [
-    ...anchorProviders,
-    AnchorService,
-  ],
+  providers: [...anchorProviders, AnchorService, AnchorListenerService],
+  exports: [...anchorProviders, AnchorService],
 };
 
 @Module(AnchorModuleConfig)
-export class AnchorModule { }
+export class AnchorModule {}

--- a/src/anchor/anchor.service.ts
+++ b/src/anchor/anchor.service.ts
@@ -5,6 +5,7 @@ import { EncoderService } from '../encoder/encoder.service';
 import { StorageService } from '../storage/storage.service';
 import { Transaction } from '../transaction/interfaces/transaction.interface';
 import { ConfigService } from '../config/config.service';
+import { TrustNetworkService } from '../trust-network/trust-network.service';
 
 @Injectable()
 export class AnchorService {
@@ -16,6 +17,7 @@ export class AnchorService {
     private readonly encoder: EncoderService,
     private readonly storage: StorageService,
     private readonly config: ConfigService,
+    private readonly trust: TrustNetworkService,
   ) {
     this.transactionTypes = [12, 15];
     this.anchorToken = '\u2693';
@@ -30,8 +32,8 @@ export class AnchorService {
     }
 
     if (anchorIndexing === 'trust') {
-      const senderRoles = await this.storage.getRolesFor(sender);
-      const isSenderTrustNetwork = Object.keys(senderRoles).length > 0;
+      const senderRoles = await this.trust.getRolesFor(sender);
+      const isSenderTrustNetwork = Object.keys(senderRoles.roles).length > 0;
 
       if (!isSenderTrustNetwork) {
         this.logger.debug(`anchor: Sender is not part of trust network`);

--- a/src/associations/associations.module.ts
+++ b/src/associations/associations.module.ts
@@ -7,9 +7,10 @@ import { AuthModule } from '../auth/auth.module';
 import { AssociationsListenerService } from './associations-listener.service';
 import { StorageModule } from '../storage/storage.module';
 import { EmitterModule } from '../emitter/emitter.module';
+import { TrustNetworkModule } from '../trust-network/trust-network.module';
 
 export const AssociationsModuleConfig = {
-  imports: [ConfigModule, LoggerModule, AuthModule, StorageModule, EmitterModule],
+  imports: [ConfigModule, LoggerModule, AuthModule, StorageModule, TrustNetworkModule, EmitterModule],
   controllers: [AssociationsController],
   providers: [AssociationsService, AssociationsListenerService],
 };

--- a/src/associations/associations.service.spec.ts
+++ b/src/associations/associations.service.spec.ts
@@ -4,40 +4,44 @@ import { AssociationsModuleConfig } from './associations.module';
 import { LoggerService } from '../logger/logger.service';
 import { ConfigService } from '../config/config.service';
 import { StorageService } from '../storage/storage.service';
+import { TrustNetworkService } from '../trust-network/trust-network.service';
 
 describe('AssociationsService', () => {
   let module: TestingModule;
   let loggerService: LoggerService;
   let storageService: StorageService;
+  let trustService: TrustNetworkService;
   let associationsService: AssociationsService;
 
   function spy() {
     const storage = {
-      saveAssociation: jest
-        .spyOn(storageService, 'saveAssociation')
-        .mockImplementation(async () => {}),
-      removeAssociation: jest
-        .spyOn(storageService, 'removeAssociation')
-        .mockImplementation(async () => {}),
-      getRolesFor: jest
-        .spyOn(storageService, 'getRolesFor')
-        .mockImplementation(async () => {
-          return { root: { description: 'The root role' } };
-        }),
-      getAssociations: jest
-        .spyOn(storageService, 'getAssociations')
-        .mockImplementation(async () => {
-          return {
-            parents: [],
-          };
-        }),
+      saveAssociation: jest.spyOn(storageService, 'saveAssociation').mockImplementation(async () => {}),
+      removeAssociation: jest.spyOn(storageService, 'removeAssociation').mockImplementation(async () => {}),
+      getRolesFor: jest.spyOn(storageService, 'getRolesFor').mockImplementation(async () => {
+        return { root: { description: 'The root role' } };
+      }),
+      getAssociations: jest.spyOn(storageService, 'getAssociations').mockImplementation(async () => {
+        return {
+          parents: [],
+        };
+      }),
+    };
+
+    const trust = {
+      getRolesFor: jest.spyOn(trustService, 'getRolesFor').mockImplementation(async () => {
+        return {
+          roles: ['root'],
+          issues_roles: [],
+          issues_authorization: [],
+        };
+      }),
     };
 
     const logger = {
       debug: jest.spyOn(loggerService, 'debug').mockImplementation(() => {}),
     };
 
-    return { storage, logger };
+    return { storage, logger, trust };
   }
 
   beforeEach(async () => {
@@ -45,6 +49,7 @@ describe('AssociationsService', () => {
 
     loggerService = module.get<LoggerService>(LoggerService);
     storageService = module.get<StorageService>(StorageService);
+    trustService = module.get<TrustNetworkService>(TrustNetworkService);
     associationsService = module.get<AssociationsService>(AssociationsService);
   });
 
@@ -63,23 +68,15 @@ describe('AssociationsService', () => {
         recipient: '3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ',
       };
 
-      await associationsService.index(
-        { transaction: transaction as any, blockHeight: 1, position: 0 },
-        'all',
-      );
+      await associationsService.index({ transaction: transaction as any, blockHeight: 1, position: 0 }, 'all');
 
-      expect(spies.storage.getRolesFor.mock.calls.length).toBe(0);
+      expect(spies.trust.getRolesFor.mock.calls.length).toBe(0);
 
       expect(spies.logger.debug.mock.calls.length).toBe(1);
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(
-        'association-service: Saving association',
-      );
+      expect(spies.logger.debug.mock.calls[0][0]).toBe('association-service: Saving association');
 
       expect(spies.storage.saveAssociation.mock.calls.length).toBe(1);
-      expect(spies.storage.saveAssociation.mock.calls[0]).toEqual([
-        transaction.sender,
-        transaction.recipient,
-      ]);
+      expect(spies.storage.saveAssociation.mock.calls[0]).toEqual([transaction.sender, transaction.recipient]);
 
       expect(spies.storage.removeAssociation.mock.calls.length).toBe(0);
     });
@@ -94,20 +91,12 @@ describe('AssociationsService', () => {
         recipient: '3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ',
       };
 
-      await associationsService.index(
-        { transaction: transaction as any, blockHeight: 1, position: 0 },
-        'all',
-      );
+      await associationsService.index({ transaction: transaction as any, blockHeight: 1, position: 0 }, 'all');
 
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(
-        'association-service: Removing association',
-      );
+      expect(spies.logger.debug.mock.calls[0][0]).toBe('association-service: Removing association');
 
       expect(spies.storage.removeAssociation.mock.calls.length).toBe(1);
-      expect(spies.storage.removeAssociation.mock.calls[0]).toEqual([
-        transaction.sender,
-        transaction.recipient,
-      ]);
+      expect(spies.storage.removeAssociation.mock.calls[0]).toEqual([transaction.sender, transaction.recipient]);
 
       expect(spies.storage.saveAssociation.mock.calls.length).toBe(0);
     });
@@ -121,14 +110,9 @@ describe('AssociationsService', () => {
         sender: '3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL',
       };
 
-      await associationsService.index(
-        { transaction: transaction as any, blockHeight: 1, position: 0 },
-        'all',
-      );
+      await associationsService.index({ transaction: transaction as any, blockHeight: 1, position: 0 }, 'all');
 
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(
-        'association-service: Unknown transaction type',
-      );
+      expect(spies.logger.debug.mock.calls[0][0]).toBe('association-service: Unknown transaction type');
 
       expect(spies.storage.saveAssociation.mock.calls.length).toBe(0);
       expect(spies.storage.removeAssociation.mock.calls.length).toBe(0);
@@ -143,19 +127,12 @@ describe('AssociationsService', () => {
         sender: '3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL',
       };
 
-      await associationsService.index(
-        { transaction: transaction as any, blockHeight: 1, position: 0 },
-        'trust',
-      );
+      await associationsService.index({ transaction: transaction as any, blockHeight: 1, position: 0 }, 'trust');
 
-      expect(spies.storage.getRolesFor.mock.calls.length).toBe(1);
-      expect(spies.storage.getRolesFor.mock.calls[0][0]).toBe(
-        '3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL',
-      );
+      expect(spies.trust.getRolesFor.mock.calls.length).toBe(1);
+      expect(spies.trust.getRolesFor.mock.calls[0][0]).toBe('3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL');
 
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(
-        'association-service: Saving association',
-      );
+      expect(spies.logger.debug.mock.calls[0][0]).toBe('association-service: Saving association');
 
       expect(spies.storage.saveAssociation.mock.calls.length).toBe(1);
     });
@@ -163,8 +140,12 @@ describe('AssociationsService', () => {
     test('should not index config "trust" if sender is not trusted', async () => {
       const spies = spy();
 
-      spies.storage.getRolesFor.mockImplementation(async () => {
-        return {};
+      spies.trust.getRolesFor.mockImplementation(async () => {
+        return {
+          roles: [],
+          issues_roles: [],
+          issues_authorization: [],
+        };
       });
 
       const transaction = {
@@ -173,14 +154,12 @@ describe('AssociationsService', () => {
         sender: '3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL',
       };
 
-      await associationsService.index(
-        { transaction: transaction as any, blockHeight: 1, position: 0 },
-        'trust',
-      );
+      await associationsService.index({ transaction: transaction as any, blockHeight: 1, position: 0 }, 'trust');
 
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(
-        'association-service: Sender is not part of trust network',
-      );
+      expect(spies.trust.getRolesFor.mock.calls.length).toBe(1);
+      expect(spies.trust.getRolesFor.mock.calls[0][0]).toBe('3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL');
+
+      expect(spies.logger.debug.mock.calls[0][0]).toBe('association-service: Sender is not part of trust network');
 
       expect(spies.storage.saveAssociation.mock.calls.length).toBe(0);
     });
@@ -190,14 +169,10 @@ describe('AssociationsService', () => {
     test('should return from storage service', async () => {
       const spies = spy();
 
-      const result = await associationsService.getAssociations(
-        '3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL',
-      );
+      const result = await associationsService.getAssociations('3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL');
 
       expect(spies.storage.getAssociations.mock.calls.length).toBe(1);
-      expect(spies.storage.getAssociations.mock.calls[0][0]).toBe(
-        '3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL',
-      );
+      expect(spies.storage.getAssociations.mock.calls[0][0]).toBe('3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL');
 
       expect(result).toEqual({ parents: [] });
     });

--- a/src/associations/associations.service.ts
+++ b/src/associations/associations.service.ts
@@ -3,23 +3,22 @@ import { IndexDocumentType } from '../index/model/index.model';
 import { LoggerService } from '../logger/logger.service';
 import { ConfigService } from '../config/config.service';
 import { StorageService } from '../storage/storage.service';
+import { TrustNetworkService } from '../trust-network/trust-network.service';
 
 @Injectable()
 export class AssociationsService {
   private transactionTypes: number[];
 
   constructor(
-    readonly logger: LoggerService,
-    readonly config: ConfigService,
-    readonly storage: StorageService,
+    private readonly logger: LoggerService,
+    private readonly config: ConfigService,
+    private readonly storage: StorageService,
+    private readonly trust: TrustNetworkService,
   ) {
     this.transactionTypes = [16, 17];
   }
 
-  async index(
-    index: IndexDocumentType,
-    associationIndexing: 'trust' | 'all',
-  ): Promise<void> {
+  async index(index: IndexDocumentType, associationIndexing: 'trust' | 'all'): Promise<void> {
     const { transaction } = index;
     const { sender, recipient } = transaction;
 
@@ -29,13 +28,11 @@ export class AssociationsService {
     }
 
     if (associationIndexing === 'trust') {
-      const senderRoles = await this.storage.getRolesFor(sender);
-      const isSenderTrustNetwork = Object.keys(senderRoles).length > 0;
+      const senderRoles = await this.trust.getRolesFor(sender);
+      const isSenderTrustNetwork = Object.keys(senderRoles.roles).length > 0;
 
       if (!isSenderTrustNetwork) {
-        this.logger.debug(
-          `association-service: Sender is not part of trust network`,
-        );
+        this.logger.debug(`association-service: Sender is not part of trust network`);
         return;
       }
     }

--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -1,28 +1,11 @@
 {
   "env": "development",
   "node": {
-    "url": "https://testnet.lto.network"
+    "url": "http://127.0.0.1:3001"
   },
   "log": {
     "level": "debug"
   },
-  "starting_block": 1645900,
-  "restart_sync": true,
-  "transaction": {
-    "indexing": true
-  },
-  "association": {
-    "indexing": "all"
-  },
-  "identity": {
-    "indexing": true
-  },
-  "anchor": {
-    "indexing": "trust"
-  },
-  "stats": {
-    "operation": true,
-    "transactions": true,
-    "supply": true
-  }
+  "starting_block": 1659500,
+  "restart_sync": true
 }

--- a/src/trust-network/trust-network.service.spec.ts
+++ b/src/trust-network/trust-network.service.spec.ts
@@ -27,7 +27,7 @@ describe('TrustNetworkService', () => {
         if (address === '3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ') return {};
 
         return {
-          authority: { sender: 'mock-sender', type: 100 }
+          authority: { sender: 'mock-sender', type: 100 },
         };
       }),
     };
@@ -44,11 +44,14 @@ describe('TrustNetworkService', () => {
         return {
           root: {
             description: 'The root',
-            issues: [{ type: 100, role: 'authority' }]
+            issues: [{ type: 100, role: 'authority' }],
           },
           authority: {
             description: 'The authority',
-            issues: [{ type: 100, role: 'university' }, { type: 101, role: 'sub_authority' }],
+            issues: [
+              { type: 100, role: 'university' },
+              { type: 101, role: 'sub_authority' },
+            ],
             authorization: ['https://www.w3.org/2018/credentials/examples/v1'],
           },
           sub_authority: {
@@ -58,7 +61,7 @@ describe('TrustNetworkService', () => {
           university: {
             description: 'The university',
             authorization: ['https://www.w3.org/2018/credentials/examples/v1'],
-          }
+          },
         };
       }),
     };
@@ -103,11 +106,20 @@ describe('TrustNetworkService', () => {
 
         const expectedRole = { type: 101, role: 'sub_authority' };
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.storage.saveRoleAssociation).toHaveBeenCalledTimes(1);
         expect(spies.storage.removeRoleAssociation).toHaveBeenCalledTimes(0);
-        expect(spies.storage.saveRoleAssociation).toHaveBeenNthCalledWith(1, transaction.party, transaction.sender, expectedRole);
+        expect(spies.storage.saveRoleAssociation).toHaveBeenNthCalledWith(
+          1,
+          transaction.party,
+          transaction.sender,
+          expectedRole,
+        );
 
         expect(spies.node.sponsor).toHaveBeenCalledTimes(0);
 
@@ -117,22 +129,39 @@ describe('TrustNetworkService', () => {
 
       test('should save multiple role associations of same type when configured', async () => {
         const spies = spy();
-        const expectedRoles = [{ type: 101, role: 'university' }, { type: 101, role: 'sub_authority' }];
+        const expectedRoles = [
+          { type: 101, role: 'university' },
+          { type: 101, role: 'sub_authority' },
+        ];
 
         spies.config.getRoles = jest.spyOn(configService, 'getRoles').mockImplementation(() => {
           return {
             authority: {
               description: 'The authority',
               issues: expectedRoles,
-            }
+            },
           };
         });
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.storage.saveRoleAssociation).toHaveBeenCalledTimes(2);
-        expect(spies.storage.saveRoleAssociation).toHaveBeenNthCalledWith(1, transaction.party, transaction.sender, expectedRoles[0]);
-        expect(spies.storage.saveRoleAssociation).toHaveBeenNthCalledWith(2, transaction.party, transaction.sender, expectedRoles[1]);
+        expect(spies.storage.saveRoleAssociation).toHaveBeenNthCalledWith(
+          1,
+          transaction.party,
+          transaction.sender,
+          expectedRoles[0],
+        );
+        expect(spies.storage.saveRoleAssociation).toHaveBeenNthCalledWith(
+          2,
+          transaction.party,
+          transaction.sender,
+          expectedRoles[1],
+        );
       });
 
       test('should send a sponsor transaction to the node if the party will be given a sponsored role', async () => {
@@ -147,24 +176,34 @@ describe('TrustNetworkService', () => {
             university: {
               description: 'University',
               sponsored: true,
-            }
+            },
           };
         });
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.node.sponsor).toHaveBeenCalledTimes(1);
         expect(spies.node.sponsor).toHaveBeenNthCalledWith(1, transaction.party);
 
         expect(spies.logger.debug).toHaveBeenCalledTimes(2);
         expect(spies.logger.debug).toHaveBeenNthCalledWith(1, 'trust-network: saving role association');
-        expect(spies.logger.debug).toHaveBeenNthCalledWith(2, 'trust-network: party is being given a sponsored role, sending a transaction to the node');
+        expect(spies.logger.debug).toHaveBeenNthCalledWith(
+          2,
+          'trust-network: party is being given a sponsored role, sending a transaction to the node',
+        );
       });
 
       test('should not send a sponsor transaction if the sponsor is the node', async () => {
         const spies = spy();
 
-        spies.node.getSponsorsOf = jest.spyOn(nodeService, 'getSponsorsOf').mockImplementation(async () => ['node-address']),
+        spies.node.getSponsorsOf = jest
+          .spyOn(nodeService, 'getSponsorsOf')
+          .mockImplementation(async () => ['node-address']);
+
         spies.config.getRoles = jest.spyOn(configService, 'getRoles').mockImplementation(() => {
           return {
             authority: {
@@ -174,11 +213,15 @@ describe('TrustNetworkService', () => {
             university: {
               description: 'University',
               sponsored: true,
-            }
+            },
           };
         });
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.node.sponsor).toHaveBeenCalledTimes(0);
       });
@@ -186,7 +229,10 @@ describe('TrustNetworkService', () => {
       test('should send a sponsor transaction if the sponsor is not the node', async () => {
         const spies = spy();
 
-        spies.node.getSponsorsOf = jest.spyOn(nodeService, 'getSponsorsOf').mockImplementation(async () => ['some-other-address']),
+        spies.node.getSponsorsOf = jest
+          .spyOn(nodeService, 'getSponsorsOf')
+          .mockImplementation(async () => ['some-other-address']);
+
         spies.config.getRoles = jest.spyOn(configService, 'getRoles').mockImplementation(() => {
           return {
             authority: {
@@ -196,11 +242,15 @@ describe('TrustNetworkService', () => {
             university: {
               description: 'University',
               sponsored: true,
-            }
+            },
           };
         });
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.node.sponsor).toHaveBeenCalledTimes(1);
       });
@@ -217,16 +267,23 @@ describe('TrustNetworkService', () => {
             university: {
               description: 'University',
               sponsored: true,
-            }
+            },
           };
         });
 
         spies.node.sponsor = jest.spyOn(nodeService, 'sponsor').mockRejectedValue(new Error('Something wrong'));
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.logger.error).toHaveBeenCalledTimes(1);
-        expect(spies.logger.error).toHaveBeenNthCalledWith(1, 'trust-network: error saving a role association: "Error: Something wrong"');
+        expect(spies.logger.error).toHaveBeenNthCalledWith(
+          1,
+          'trust-network: error saving a role association: "Error: Something wrong"',
+        );
       });
     });
 
@@ -239,7 +296,11 @@ describe('TrustNetworkService', () => {
 
         const expectedRole = { type: 101, role: 'sub_authority' };
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.storage.saveRoleAssociation).toHaveBeenCalledTimes(0);
         expect(spies.storage.removeRoleAssociation).toHaveBeenCalledTimes(1);
@@ -250,12 +311,18 @@ describe('TrustNetworkService', () => {
 
         expect(spies.logger.debug).toHaveBeenCalledTimes(2);
         expect(spies.logger.debug).toHaveBeenNthCalledWith(1, 'trust-network: removing role association');
-        expect(spies.logger.debug).toHaveBeenNthCalledWith(2, 'trust-network: party has no more sponsored roles, sending a transaction to the node');
+        expect(spies.logger.debug).toHaveBeenNthCalledWith(
+          2,
+          'trust-network: party has no more sponsored roles, sending a transaction to the node',
+        );
       });
 
       test('should remove multiple role associations of same type when configured', async () => {
         const spies = spy();
-        const expectedRoles = [{ type: 101, role: 'university' }, { type: 101, role: 'sub_authority' }];
+        const expectedRoles = [
+          { type: 101, role: 'university' },
+          { type: 101, role: 'sub_authority' },
+        ];
 
         // @ts-ignore
         transaction.type = 17;
@@ -265,11 +332,15 @@ describe('TrustNetworkService', () => {
             authority: {
               description: 'The authority',
               issues: expectedRoles,
-            }
+            },
           };
         });
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.storage.removeRoleAssociation).toHaveBeenCalledTimes(2);
         expect(spies.storage.removeRoleAssociation).toHaveBeenNthCalledWith(1, transaction.party, expectedRoles[0]);
@@ -288,26 +359,32 @@ describe('TrustNetworkService', () => {
             university: {
               description: 'University',
               sponsored: true,
+            },
+          };
+        });
+
+        spies.storage.getRolesFor = jest
+          .spyOn(storageService, 'getRolesFor')
+          .mockImplementation(async (address: string) => {
+            if (address === '3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ') {
+              return {
+                university: { sender: 'mock-sender', type: 101 },
+              };
             }
-          };
-        });
 
-        spies.storage.getRolesFor = jest.spyOn(storageService, 'getRolesFor').mockImplementation(async (address: string) => {
-          if (address === '3Mv7ajrPLKewkBNqfxwRZoRwW6fziehp7dQ') {
             return {
-              university: { sender: 'mock-sender', type: 101 }
+              authority: { sender: 'mock-sender', type: 100 },
             };
-          };
-
-          return {
-            authority: { sender: 'mock-sender', type: 100 }
-          };
-        });
+          });
 
         // @ts-ignore
         transaction.type = 17;
 
-        await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+        await trustNetworkService.index({
+          transaction,
+          blockHeight: 1,
+          position: 0,
+        });
 
         expect(spies.node.cancelSponsor).toHaveBeenCalledTimes(0);
       });
@@ -319,7 +396,11 @@ describe('TrustNetworkService', () => {
       // @ts-ignore
       delete transaction.party;
 
-      await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+      await trustNetworkService.index({
+        transaction,
+        blockHeight: 1,
+        position: 0,
+      });
 
       expect(spies.storage.saveRoleAssociation).toHaveBeenCalledTimes(0);
     });
@@ -330,7 +411,11 @@ describe('TrustNetworkService', () => {
       // @ts-ignore
       delete transaction.associationType;
 
-      await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+      await trustNetworkService.index({
+        transaction,
+        blockHeight: 1,
+        position: 0,
+      });
 
       expect(spies.storage.saveRoleAssociation).toHaveBeenCalledTimes(0);
     });
@@ -341,7 +426,11 @@ describe('TrustNetworkService', () => {
       // @ts-ignore
       transaction.type = 1;
 
-      await trustNetworkService.index({transaction, blockHeight: 1, position: 0});
+      await trustNetworkService.index({
+        transaction,
+        blockHeight: 1,
+        position: 0,
+      });
 
       expect(spies.storage.saveRoleAssociation).toHaveBeenCalledTimes(0);
     });
@@ -354,9 +443,12 @@ describe('TrustNetworkService', () => {
       const result = await trustNetworkService.getRolesFor('mock-party');
 
       const expected: RoleData = {
-        roles: [ 'authority' ],
-        issues_roles: [{ type: 100, role: 'university' }, { type: 101, role: 'sub_authority' }],
-        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1']
+        roles: ['authority'],
+        issues_roles: [
+          { type: 100, role: 'university' },
+          { type: 101, role: 'sub_authority' },
+        ],
+        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1'],
       };
 
       expect(spies.config.getRoles).toHaveBeenCalledTimes(1);
@@ -370,14 +462,22 @@ describe('TrustNetworkService', () => {
     test('should return root roles if address is in node wallet', async () => {
       const spies = spy();
 
+      spies.storage.getRolesFor = jest.spyOn(storageService, 'getRolesFor').mockImplementation(async () => {
+        return { authority: { sender: 'mock-sender', type: 100 } };
+      });
+
       const result = await trustNetworkService.getRolesFor('node-address');
       const expected: RoleData = {
-        roles: [ 'root' ],
-        issues_roles: [{ type: 100, role: 'authority' }],
-        issues_authorization: []
+        roles: ['root', 'authority'],
+        issues_roles: [
+          { type: 100, role: 'authority' },
+          { type: 100, role: 'university' },
+          { type: 101, role: 'sub_authority' },
+        ],
+        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1'],
       };
 
-      expect(spies.storage.getRolesFor).toHaveBeenCalledTimes(0);
+      expect(spies.storage.getRolesFor).toHaveBeenCalledTimes(1);
 
       expect(result).toStrictEqual(expected);
     });
@@ -394,9 +494,12 @@ describe('TrustNetworkService', () => {
 
       const result = await trustNetworkService.getRolesFor('mock-party');
       const expected: RoleData = {
-        roles: [ 'authority', 'sub_authority' ],
-        issues_roles: [{ type: 100, role: 'university' }, { type: 101, role: 'sub_authority' }],
-        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1']
+        roles: ['authority', 'sub_authority'],
+        issues_roles: [
+          { type: 100, role: 'university' },
+          { type: 101, role: 'sub_authority' },
+        ],
+        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1'],
       };
 
       expect(result).toStrictEqual(expected);
@@ -414,9 +517,12 @@ describe('TrustNetworkService', () => {
 
       const result = await trustNetworkService.getRolesFor('mock-party');
       const expected: RoleData = {
-        roles: [ 'authority', 'university' ],
-        issues_roles: [{ type: 100, role: 'university' }, { type: 101, role: 'sub_authority' }],
-        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1']
+        roles: ['authority', 'university'],
+        issues_roles: [
+          { type: 100, role: 'university' },
+          { type: 101, role: 'sub_authority' },
+        ],
+        issues_authorization: ['https://www.w3.org/2018/credentials/examples/v1'],
       };
 
       expect(result).toStrictEqual(expected);
@@ -425,14 +531,16 @@ describe('TrustNetworkService', () => {
     test('should not error if address has no roles', async () => {
       const spies = spy();
 
-      spies.storage.getRolesFor = jest.spyOn(storageService, 'getRolesFor').mockImplementation(async () => { return {} });
+      spies.storage.getRolesFor = jest.spyOn(storageService, 'getRolesFor').mockImplementation(async () => {
+        return {};
+      });
 
       const result = await trustNetworkService.getRolesFor('mock-party');
 
       const expected: RoleData = {
         roles: [],
         issues_roles: [],
-        issues_authorization: []
+        issues_authorization: [],
       };
 
       expect(result).toStrictEqual(expected);

--- a/src/trust-network/trust-network.service.ts
+++ b/src/trust-network/trust-network.service.ts
@@ -9,14 +9,13 @@ import { Transaction } from 'transaction/interfaces/transaction.interface';
 
 @Injectable()
 export class TrustNetworkService {
-
   private transactionTypes: number[];
 
   constructor(
     private readonly logger: LoggerService,
     private readonly storage: StorageService,
     private readonly config: ConfigService,
-    private readonly node: NodeService
+    private readonly node: NodeService,
   ) {
     this.transactionTypes = [16, 17];
   }
@@ -24,7 +23,7 @@ export class TrustNetworkService {
   async index(index: IndexDocumentType): Promise<void> {
     const { transaction } = index;
 
-    if (this.transactionTypes.indexOf(transaction.type) === -1){
+    if (this.transactionTypes.indexOf(transaction.type) === -1) {
       this.logger.debug(`trust-network: unknown transaction type`);
       return;
     }
@@ -35,7 +34,9 @@ export class TrustNetworkService {
     }
 
     if (!transaction.associationType) {
-      this.logger.debug(`trust-network: transaction ${transaction.id} didn't have an association type, skipped indexing`);
+      this.logger.debug(
+        `trust-network: transaction ${transaction.id} didn't have an association type, skipped indexing`,
+      );
       return;
     }
 
@@ -61,10 +62,15 @@ export class TrustNetworkService {
     const root = await this.node.getNodeWallet();
 
     if (root === address) {
-      roles = { root: { } };
-    } else {
-      roles = await this.storage.getRolesFor(address);
+      roles = { root: {} };
     }
+
+    const storageRoles = await this.storage.getRolesFor(address);
+
+    roles = {
+      ...roles,
+      ...storageRoles,
+    };
 
     for (const role in roles) {
       const configData = configRoles[role];
@@ -115,7 +121,7 @@ export class TrustNetworkService {
         this.logger.debug(`trust-network: party is being given a sponsored role, sending a transaction to the node`);
         await this.node.sponsor(transaction.party);
       }
-    } catch(error) {
+    } catch (error) {
       this.logger.error(`trust-network: error saving a role association: "${error}"`);
     }
   }


### PR DESCRIPTION
- Fixes `anchor` and `association` indexing for when they're configured to `"trust"`
  - `storage.getRolesFor` was being called instead of `trustNetwork.getRolesFor`, so it never took into consideration the node's own address as `root`
- Adds line width to `.prettierrc` as `120`, for better auto formatting
- Some auto formatting
- Fixes an issue with `trustNetworkService` where if an address was the node's address, only the `root` role would be returned, and not all of the roles given to that address (via association transactions for example)
- Fixes and adds tests where necessary

---