### PR TITLE
[#139] Fix /transactions/addresses endpoint return

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN npm i
 # Bundle app source
 COPY . .
 
+RUN echo $(git describe --tags) > ./version.txt
+
 RUN npm run build
 
 RUN rm -rf node_modules/
@@ -27,6 +29,7 @@ FROM node:dubnium-alpine
 # Move the build files from build folder to app folder
 WORKDIR /usr/app
 COPY --from=build /usr/src/dist ./
+COPY --from=build /usr/src/version.txt ./
 COPY --from=build /usr/src/node_modules ./node_modules/
 
 ADD package.json ./

--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -6,6 +6,11 @@
   "log": {
     "level": "debug"
   },
-  "starting_block": 1659500,
-  "restart_sync": true
+  "starting_block": 1600000,
+  "transaction": {
+    "indexing": true
+  },
+  "anchor": {
+    "indexing": "all"
+  }
 }

--- a/src/index/index-monitor.service.ts
+++ b/src/index/index-monitor.service.ts
@@ -119,14 +119,11 @@ export class IndexMonitorService {
     this.processing = true;
 
     const blockHeight = await this.node.getLastBlockHeight();
-    const processingHeight =
-      (await this.storage.getProcessingHeight()) || this.lastBlock;
+    const processingHeight = (await this.storage.getProcessingHeight()) || this.lastBlock;
     const ranges = this.node.getBlockRanges(processingHeight, blockHeight);
 
     for (const range of ranges) {
-      this.logger.info(
-        `index-monitor: processing blocks ${range.from} to ${range.to}`,
-      );
+      this.logger.info(`index-monitor: processing blocks ${range.from} to ${range.to}`);
       const blocks = await this.node.getBlocks(range.from, range.to);
 
       for (const block of blocks) {
@@ -150,11 +147,7 @@ export class IndexMonitorService {
     }
   }
 
-  processTransaction(
-    transaction: Transaction,
-    blockHeight: number,
-    position: number,
-  ) {
+  processTransaction(transaction: Transaction, blockHeight: number, position: number) {
     return this.indexer.index({ transaction, blockHeight, position });
   }
 }

--- a/src/leveldb/classes/leveldb.connection.spec.ts
+++ b/src/leveldb/classes/leveldb.connection.spec.ts
@@ -33,7 +33,7 @@ describe('LeveldbConnection', () => {
     test("should set a value to leveldb if it doesn't exist", async () => {
       const spies = spy();
 
-      spies.connection.get.mockRejectedValue('');
+      spies.connection.get.mockRejectedValue(new Error('key not found in database'));
       spies.connection.put.mockImplementation(async () => 'fake_value');
       const levelDBConnection = new LeveldbConnection(spies.connection as any);
 

--- a/src/leveldb/classes/leveldb.connection.spec.ts
+++ b/src/leveldb/classes/leveldb.connection.spec.ts
@@ -30,7 +30,7 @@ describe('LeveldbConnection', () => {
   });
 
   describe('add()', () => {
-    test('should set a value to leveldb if it doesn\'t exist', async () => {
+    test("should set a value to leveldb if it doesn't exist", async () => {
       const spies = spy();
 
       spies.connection.get.mockRejectedValue('');
@@ -73,6 +73,42 @@ describe('LeveldbConnection', () => {
       expect(spies.connection.get.mock.calls.length).toBe(1);
       expect(spies.connection.get.mock.calls[0]).toEqual(['fake_key']);
     });
+
+    test('should catch "key not found in database" error and return empty object', async () => {
+      const spies = spy();
+
+      spies.connection.get.mockImplementation(async () => {
+        throw new Error('NotFoundError: Key not found in database [lto:anchor:some-anchor]');
+      });
+
+      const levelDBConnection = new LeveldbConnection(spies.connection as any);
+
+      const result = await levelDBConnection.get('fake_key');
+
+      expect(spies.connection.get.mock.calls.length).toBe(1);
+      expect(spies.connection.get.mock.calls[0]).toEqual(['fake_key']);
+
+      expect(result).toEqual(null);
+    });
+
+    test('should rethrow errors other than "key not found in database"', async () => {
+      const spies = spy();
+
+      spies.connection.get.mockImplementation(async () => {
+        throw new Error('some really bad error here...');
+      });
+
+      const levelDBConnection = new LeveldbConnection(spies.connection as any);
+
+      try {
+        await levelDBConnection.get('fake_key');
+      } catch (error) {
+        expect(error).toEqual(new Error('some really bad error here...'));
+
+        expect(spies.connection.get.mock.calls.length).toBe(1);
+        expect(spies.connection.get.mock.calls[0]).toEqual(['fake_key']);
+      }
+    });
   });
 
   describe('mget()', () => {
@@ -83,8 +119,7 @@ describe('LeveldbConnection', () => {
       spies.connection.get.mockImplementation(async () => values.shift());
       const levelDBConnection = new LeveldbConnection(spies.connection as any);
 
-      expect(await levelDBConnection.mget(['fake_key1', 'fake_key2']))
-        .toEqual(['fake_value1', 'fake_value2']);
+      expect(await levelDBConnection.mget(['fake_key1', 'fake_key2'])).toEqual(['fake_value1', 'fake_value2']);
       expect(spies.connection.get.mock.calls.length).toBe(2);
       expect(spies.connection.get.mock.calls[0]).toEqual(['fake_key1']);
       expect(spies.connection.get.mock.calls[1]).toEqual(['fake_key2']);

--- a/src/leveldb/classes/leveldb.connection.ts
+++ b/src/leveldb/classes/leveldb.connection.ts
@@ -27,7 +27,7 @@ export class LeveldbConnection {
     return Promise.all(promises);
   }
 
-  async add(key: level.KeyType, value: string): Promise<void> {
+  async add(key: level.KeyType, value: string): Promise<string> {
     await this.incrLock.acquireAsync();
 
     try {
@@ -35,7 +35,8 @@ export class LeveldbConnection {
 
       if (existing) return existing;
 
-      await this.connection.put(key, value);
+      const result = await this.connection.put(key, value);
+      return result;
     } finally {
       this.incrLock.release();
     }
@@ -49,12 +50,13 @@ export class LeveldbConnection {
     return this.connection.del(key);
   }
 
-  async incr(key): Promise<void> {
+  async incr(key): Promise<string> {
     await this.incrLock.acquireAsync();
 
     try {
       const count = Number(await this.get(key));
-      await this.set(key, String(count + 1));
+      const result = await this.set(key, String(count + 1));
+      return result;
     } finally {
       this.incrLock.release();
     }

--- a/src/leveldb/classes/leveldb.connection.ts
+++ b/src/leveldb/classes/leveldb.connection.ts
@@ -23,7 +23,7 @@ export class LeveldbConnection {
   }
 
   mget(keys: level.KeyType[]): Promise<string[]> {
-    const promises = keys.map((key: string) => this.connection.get(key).catch(() => null));
+    const promises = keys.map((key: string) => this.get(key));
     return Promise.all(promises);
   }
 
@@ -31,7 +31,7 @@ export class LeveldbConnection {
     await this.incrLock.acquireAsync();
 
     try {
-      const existing = await this.connection.get(key).catch(() => null);
+      const existing = await this.get(key);
 
       if (existing) return existing;
 

--- a/src/storage/types/leveldb.storage.service.spec.ts
+++ b/src/storage/types/leveldb.storage.service.spec.ts
@@ -139,48 +139,6 @@ describe('LevelDbStorageService', () => {
       expect(spies.leveldbConnection.get.mock.calls.length).toBe(1);
       expect(spies.leveldbConnection.get.mock.calls[0][0]).toBe(hash);
     });
-
-    test('should catch "key not found in database" error and return empty object', async () => {
-      const spies = spy();
-
-      spies.leveldbConnection.get = jest.fn().mockImplementation(async () => {
-        throw new Error('NotFoundError: Key not found in database [lto:anchor:some-anchor]');
-      });
-
-      const hash = '2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE';
-
-      const result = await storageService.getObject(hash);
-
-      expect(spies.leveldb.connect.mock.calls.length).toBe(1);
-      expect(spies.leveldb.connect.mock.calls[0][0]).toBe('lto-index');
-
-      expect(spies.leveldbConnection.get.mock.calls.length).toBe(1);
-      expect(spies.leveldbConnection.get.mock.calls[0][0]).toBe(hash);
-
-      expect(result).toEqual({});
-    });
-
-    test('should rethrow errors other than "key not found in database"', async () => {
-      const spies = spy();
-
-      spies.leveldbConnection.get = jest.fn().mockImplementation(async () => {
-        throw new Error('some really bad error here...');
-      });
-
-      const hash = '2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE';
-
-      try {
-        await storageService.getObject(hash);
-      } catch (error) {
-        expect(error).toEqual(new Error('some really bad error here...'));
-
-        expect(spies.leveldb.connect.mock.calls.length).toBe(1);
-        expect(spies.leveldb.connect.mock.calls[0][0]).toBe('lto-index');
-
-        expect(spies.leveldbConnection.get.mock.calls.length).toBe(1);
-        expect(spies.leveldbConnection.get.mock.calls[0][0]).toBe(hash);
-      }
-    });
   });
 
   describe('setObject()', () => {

--- a/src/storage/types/leveldb.storage.service.ts
+++ b/src/storage/types/leveldb.storage.service.ts
@@ -64,14 +64,7 @@ export class LeveldbStorageService implements StorageInterface, OnModuleInit, On
   }
 
   async getObject(key: string): Promise<object> {
-    const res = await this.getValue(key).catch(error => {
-      if (error.message?.toLowerCase().includes('key not found in database')) {
-        return null;
-      }
-
-      throw error;
-    });
-
+    const res = await this.getValue(key);
     return res ? JSON.parse(res) : {};
   }
 

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -6,29 +6,26 @@ import { StorageService } from '../storage/storage.service';
 
 @Injectable()
 export class TransactionService {
-  constructor(
-    private readonly logger: LoggerService,
-    private readonly storage: StorageService,
-  ) { }
+  constructor(private readonly logger: LoggerService, private readonly storage: StorageService) {}
 
-  getAllTypes(): Array<{ id: string, types: number[] }> {
-    return Object.keys(TransactionTypes).map((k) => TransactionTypes[k]);
+  getAllTypes(): Array<{ id: string; types: number[] }> {
+    return Object.keys(TransactionTypes).map(k => TransactionTypes[k]);
   }
 
   getIdentifiers(): string[] {
     const types = this.getAllTypes();
-    return types.map((tx) => tx.id);
+    return types.map(tx => tx.id);
   }
 
   getIdentifierByType(type: number): string | null {
     const types = this.getAllTypes();
-    const match = types.find((tx) => tx.types.indexOf(type) > -1);
+    const match = types.find(tx => tx.types.indexOf(type) > -1);
     return match ? match.id : null;
   }
 
   getIdentifiersByType(type: number): string[] {
     const types = this.getAllTypes();
-    return types.filter((tx) => tx.types.indexOf(type) > -1).map((match) => match.id);
+    return types.filter(tx => tx.types.indexOf(type) > -1).map(match => match.id);
   }
 
   hasIdentifier(identifier): boolean {
@@ -36,7 +33,7 @@ export class TransactionService {
     return identifiers.indexOf(identifier) > -1;
   }
 
-  async getStats(type: string, from: number, to: number): Promise<{period: string, count: number}[]> {
+  async getStats(type: string, from: number, to: number): Promise<{ period: string; count: number }[]> {
     return this.storage.getTxStats(type, from, to);
   }
 

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,0 +1,1 @@
+unknown


### PR DESCRIPTION
- Fixes the issue with `/transactions/addresses` endpoint
  - The indexing was not behaving properly due to an error implementing `AwaitLock`
  - `AwaitLock` was getting stuck when multiple listeners were activated, so the data was never saved to the database
- Fixes/moves `leveldb` connection handling of errors on `.get` method
  - Instead of throwing an error when value is not found, returns an empty list. This was done on the `leveldb.service` previously, but a better place is on the `leveldb.connection`, as it covers more use-cases  
- Some identation and linting fixes

---

closes #139 