### PR TITLE
Ability to batch hash requests into a single anchor tx

### DIFF
--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -35,14 +35,6 @@ export class ConfigService {
     return this.config.get('auth.token');
   }
 
-  getAnchorFee(): number {
-    return Number(this.config.get('fees.anchor'));
-  }
-
-  getSponsorFee(): number {
-    return Number(this.config.get('fees.sponsor'));
-  }
-
   getRedisClient(): string | string[] {
     return this.getRedisUrl() || this.getRedisCluster().split(';');
   }
@@ -113,5 +105,9 @@ export class ConfigService {
   // @todo: add support for more chains (only eip155 for now)
   isEip155IndexingEnabled(): boolean {
     return !!this.config.get('cross_chain.eip155.indexing');
+  }
+
+  isAnchorBatched(): boolean {
+    return !!this.config.get('anchor.batch');
   }
 }

--- a/src/config/data/default.schema.json
+++ b/src/config/data/default.schema.json
@@ -75,6 +75,12 @@
       "default": "none",
       "format": ["none", "trust", "all"],
       "env": "ANCHOR_INDEXING"
+    },
+    "batch": {
+      "doc": "Batch hashes for anchor transaction",
+      "default": false,
+      "format": "Boolean",
+      "env": "ANCHOR_BATCH"
     }
   },
   "stats": {
@@ -96,18 +102,6 @@
       "default": false,
       "format": "Boolean",
       "env": "STATS_INDEXING"
-    }
-  },
-  "fees": {
-    "anchor": {
-      "doc": "Fees for anchor transactions",
-      "default": 35000000,
-      "env": "FEES_ANCHOR"
-    },
-    "sponsor": {
-      "doc": "Fees for sponsor transactions",
-      "default": 500000000,
-      "env": "FEES_SPONSOR"
     }
   },
   "redis": {

--- a/src/hash/hash-listener.service.ts
+++ b/src/hash/hash-listener.service.ts
@@ -1,0 +1,32 @@
+import { IndexEvent, IndexEventsReturnType } from '../index/index.events';
+import { EmitterService } from '../emitter/emitter.service';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { HashService } from './hash.service';
+import { ConfigService } from '../config/config.service';
+import { LoggerService } from '../logger/logger.service';
+
+@Injectable()
+export class HashListenerService implements OnModuleInit {
+  constructor(
+    private readonly indexEmitter: EmitterService<IndexEventsReturnType>,
+    private readonly hashService: HashService,
+    private readonly config: ConfigService,
+    private readonly logger: LoggerService,
+  ) { }
+
+  onModuleInit() {
+    if (!this.config.isAnchorBatched()) {
+      this.logger.debug(`hash-listener: Not batching anchors`);
+      return;
+    }
+
+    this.onIndexBlock();
+  }
+
+  async onIndexBlock() {
+    this.indexEmitter.on(
+      IndexEvent.IndexBlock,
+      () => this.hashService.trigger(),
+    );
+  }
+}

--- a/src/hash/hash.controller.spec.ts
+++ b/src/hash/hash.controller.spec.ts
@@ -4,9 +4,11 @@ import request from 'supertest';
 import { HashModuleConfig } from './hash.module';
 import { NodeService } from '../node/node.service';
 import { ConfigService } from '../config/config.service';
+import { HashService } from './hash.service';
 
 describe('HashController', () => {
   let module: TestingModule;
+  let hashService: HashService;
   let nodeService: NodeService;
   let configService: ConfigService;
   let app: INestApplication;
@@ -25,13 +27,15 @@ describe('HashController', () => {
 
   function spy() {
     const hash = {
-      anchor: jest.spyOn(nodeService, 'anchor')
-        .mockImplementation(async () => chainpoint),
+      anchor: jest.spyOn(hashService, 'anchor').mockImplementation(async () => chainpoint),
+    };
+
+    const node = {
       getTransactionByHash: jest.spyOn(nodeService, 'getTransactionByHash')
         .mockImplementation(async () => chainpoint),
     };
 
-    return { hash };
+    return { hash, node };
   }
 
   beforeEach(async () => {
@@ -39,6 +43,7 @@ describe('HashController', () => {
     app = module.createNestApplication();
     await app.init();
 
+    hashService = module.get<HashService>(HashService);
     nodeService = module.get<NodeService>(NodeService);
     configService = module.get<ConfigService>(ConfigService);
   });
@@ -122,8 +127,8 @@ describe('HashController', () => {
       expect(res.header['content-type']).toBe('application/json; charset=utf-8');
       expect(res.body).toEqual({ chainpoint });
 
-      expect(spies.hash.getTransactionByHash.mock.calls.length).toBe(1);
-      expect(spies.hash.getTransactionByHash.mock.calls[0][0]).toBe(hash);
+      expect(spies.node.getTransactionByHash.mock.calls.length).toBe(1);
+      expect(spies.node.getTransactionByHash.mock.calls[0][0]).toBe(hash);
     });
   });
 
@@ -141,8 +146,8 @@ describe('HashController', () => {
       expect(res.header['content-type']).toBe('application/json; charset=utf-8');
       expect(res.body).toEqual({ chainpoint });
 
-      expect(spies.hash.getTransactionByHash.mock.calls.length).toBe(1);
-      expect(spies.hash.getTransactionByHash.mock.calls[0][0]).toBe(hash);
+      expect(spies.node.getTransactionByHash.mock.calls.length).toBe(1);
+      expect(spies.node.getTransactionByHash.mock.calls[0][0]).toBe(hash);
     });
   });
 });

--- a/src/hash/hash.controller.ts
+++ b/src/hash/hash.controller.ts
@@ -48,7 +48,12 @@ export class HashController {
 
     try {
       const chainpoint = await this.node.anchor(hash, encoding);
-      res.status(200).json({ chainpoint });
+
+      if (!chainpoint) {
+        res.status(202);
+      } else {
+        res.status(200).json({chainpoint});
+      }
     } catch (e) {
       this.logger.error(`hash-controller: failed to anchor '${e}'`, { stack: e.stack });
 

--- a/src/hash/hash.controller.ts
+++ b/src/hash/hash.controller.ts
@@ -6,12 +6,14 @@ import { HashDto } from './dto/hash.dto';
 import { NodeService } from '../node/node.service';
 import { EncoderService } from '../encoder/encoder.service';
 import { BearerAuthGuard } from '../auth/auth.guard';
+import { HashService } from './hash.service';
 
 @Controller('hash')
 @ApiTags('hash')
 export class HashController {
   constructor(
     private readonly logger: LoggerService,
+    private readonly hash: HashService,
     private readonly node: NodeService,
     private readonly encoder: EncoderService,
   ) { }
@@ -47,7 +49,7 @@ export class HashController {
     }
 
     try {
-      const chainpoint = await this.node.anchor(hash, encoding);
+      const chainpoint = await this.hash.anchor(hash, encoding);
 
       if (!chainpoint) {
         res.status(202);

--- a/src/hash/hash.module.ts
+++ b/src/hash/hash.module.ts
@@ -6,11 +6,13 @@ import { NodeModule } from '../node/node.module';
 import { StorageModule } from '../storage/storage.module';
 import { EncoderModule } from '../encoder/encoder.module';
 import { AuthModule } from '../auth/auth.module';
+import { HashService } from './hash.service';
+import { HashListenerService } from './hash-listener.service';
 
 export const HashModuleConfig = {
   imports: [LoggerModule, ConfigModule, NodeModule, StorageModule, EncoderModule, AuthModule],
   controllers: [HashController],
-  providers: [],
+  providers: [HashService, HashListenerService],
 };
 
 @Module(HashModuleConfig)

--- a/src/hash/hash.module.ts
+++ b/src/hash/hash.module.ts
@@ -8,9 +8,10 @@ import { EncoderModule } from '../encoder/encoder.module';
 import { AuthModule } from '../auth/auth.module';
 import { HashService } from './hash.service';
 import { HashListenerService } from './hash-listener.service';
+import { EmitterModule } from '../emitter/emitter.module';
 
 export const HashModuleConfig = {
-  imports: [LoggerModule, ConfigModule, NodeModule, StorageModule, EncoderModule, AuthModule],
+  imports: [LoggerModule, ConfigModule, NodeModule, StorageModule, EncoderModule, AuthModule, EmitterModule],
   controllers: [HashController],
   providers: [HashService, HashListenerService],
 };

--- a/src/hash/hash.service.ts
+++ b/src/hash/hash.service.ts
@@ -1,0 +1,41 @@
+import {Injectable} from '@nestjs/common';
+import {NodeService} from '../node/node.service';
+import {EncoderService} from '../encoder/encoder.service';
+import {ConfigService} from '../config/config.service';
+
+@Injectable()
+export class HashService
+{
+    private hashes;
+
+    constructor(
+        private readonly config: ConfigService,
+        private readonly node: NodeService,
+        private readonly encoder: EncoderService,
+    ) { }
+
+    async anchor(
+        hash: string,
+        encoding: string,
+    ): Promise<{
+        '@context';
+        type;
+        targetHash;
+        anchors;
+    } | null> {
+        if (this.config.isAnchorBatched()) {
+            this.hashes.push(this.encoder.base58Encode(this.encoder.decode(hash, encoding)));
+            return null;
+        }
+
+        return await this.node.anchor(hash, encoding);
+    }
+
+    async trigger(): Promise<void>
+    {
+        if (this.hashes.length === 0) return;
+
+        const chunks = [...Array(Math.ceil(this.hashes.length / 100))].map(_ => this.hashes.splice(0, 100));
+        await Promise.all(chunks.map(chunk => this.node.anchorAll(...chunk)));
+    }
+}

--- a/src/index/index.events.ts
+++ b/src/index/index.events.ts
@@ -2,8 +2,10 @@ import { IndexDocumentType } from './model/index.model';
 
 export interface IndexEventsReturnType {
   IndexTransaction: IndexDocumentType;
+  IndexBlock: number;
 }
 
 export const IndexEvent: { [P in keyof IndexEventsReturnType]: P } = {
   IndexTransaction: 'IndexTransaction',
-}
+  IndexBlock: 'IndexBlock',
+};

--- a/src/index/index.service.spec.ts
+++ b/src/index/index.service.spec.ts
@@ -42,14 +42,16 @@ describe('IndexService', () => {
     test('should ignore genesis transactions', async () => {
       const spies = spy();
 
-      const type = 'anchor';
       const transaction = { id: 'fake_transaction', type: 1, sender: 'fake_sender' };
       await indexService.index({ transaction: transaction as any, blockHeight: 1, position: 0});
 
-      expect(spies.emitter.emit.mock.calls.length).toBe(1);
+      expect(spies.emitter.emit.mock.calls.length).toBe(2);
+      expect(spies.emitter.emit.mock.calls[0][0]).toBe('IndexBlock');
+      expect(spies.emitter.emit.mock.calls[1][0]).toBe('IndexTransaction');
     });
 
     test('should index the anchor transaction', async () => {
+      indexService.lastBlock = 1; // Don't emit IndexBlock
       const spies = spy();
 
       const type = 'anchor';

--- a/src/index/index.service.ts
+++ b/src/index/index.service.ts
@@ -24,6 +24,7 @@ export class IndexService {
   async index(index: IndexDocumentType): Promise<boolean> {
     if (this.lastBlock !== index.blockHeight) {
       this.txCache = [];
+      this.event.emit(IndexEvent.IndexBlock, index.blockHeight);
     }
 
     this.lastBlock = index.blockHeight;

--- a/src/index/index.service.ts
+++ b/src/index/index.service.ts
@@ -8,7 +8,7 @@ import { LoggerService } from '../logger/logger.service';
 export class IndexService {
 
   public lastBlock: number;
-  public txCache: string[];
+  public txCache: string[] = [];
 
   constructor(
     private readonly logger: LoggerService,

--- a/src/leveldb/classes/leveldb.connection.ts
+++ b/src/leveldb/classes/leveldb.connection.ts
@@ -50,12 +50,12 @@ export class LeveldbConnection {
     return this.connection.del(key);
   }
 
-  async incr(key): Promise<string> {
+  async incr(key, amount = 1): Promise<string> {
     await this.incrLock.acquireAsync();
 
     try {
       const count = Number(await this.get(key));
-      const result = await this.set(key, String(count + 1));
+      const result = await this.set(key, String(count + amount));
       return result;
     } finally {
       this.incrLock.release();

--- a/src/node/node.service.spec.ts
+++ b/src/node/node.service.spec.ts
@@ -68,7 +68,6 @@ describe('NodeService', () => {
     };
 
     const config = {
-      getSponsorFee: jest.spyOn(configService, 'getSponsorFee').mockImplementation(() => 5000),
     };
 
     return { api, node, storage, config };
@@ -428,7 +427,7 @@ describe('NodeService', () => {
         version: 1,
         type: 18,
         recipient: 'some-recipient',
-        fee: 5000,
+        fee: 500000000,
       });
     });
   });
@@ -444,7 +443,7 @@ describe('NodeService', () => {
         version: 1,
         type: 19,
         recipient: 'some-recipient',
-        fee: 5000,
+        fee: 500000000,
       });
     });
   });

--- a/src/stats/operations/operations.service.spec.ts
+++ b/src/stats/operations/operations.service.spec.ts
@@ -76,7 +76,7 @@ describe('OperationsService', () => {
       const result = await operationsService.getOperationStats(18600, 18603);
 
       expect(spies.storage.getOperationStats.mock.calls.length).toBe(1);
-      expect(result).toBe([
+      expect(result).toEqual([
         { period: '2020-12-04 00:00:00', count: 300 },
         { period: '2020-12-05 00:00:00', count: 329 },
         { period: '2020-12-06 00:00:00', count: 402 },

--- a/src/stats/operations/operations.service.spec.ts
+++ b/src/stats/operations/operations.service.spec.ts
@@ -94,10 +94,6 @@ describe('OperationsService', () => {
       expect(spies.storage.incrOperationStats.mock.calls.length).toBe(1);
       expect(spies.storage.incrOperationStats.mock.calls[0][0]).toBe(18600);
       expect(spies.storage.incrOperationStats.mock.calls[0][1]).toBe(3);
-
-      expect(spies.logger.debug.mock.calls.length).toBe(1);
-      expect(spies.logger.debug.mock.calls[0][0])
-          .toBe(`operation stats: 3 transfers: increase stats: ${transaction.id}`);
     });
 
     test('should increase stats once if transaction has no transfer count', async () => {
@@ -110,10 +106,6 @@ describe('OperationsService', () => {
       await operationsService.incrOperationStats(transaction);
 
       expect(spies.storage.incrOperationStats.mock.calls.length).toBe(1);
-
-      expect(spies.logger.debug.mock.calls.length).toBe(1);
-      expect(spies.logger.debug.mock.calls[0][0])
-          .toBe(`operation stats: 1 transfers: increase stats: ${transaction.id}`);
     });
 
     test('should increase stats based on the anchor hashes', async () => {
@@ -127,9 +119,6 @@ describe('OperationsService', () => {
       expect(spies.storage.incrOperationStats.mock.calls[0][0]).toBe(18600);
       expect(spies.storage.incrOperationStats.mock.calls[0][1]).toBe(2);
       expect(spies.transaction.getIdentifiersByType.mock.calls.length).toBe(1);
-
-      expect(spies.logger.debug.mock.calls.length).toBe(1);
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(`increase operation stats by 2: ${transaction.id}`);
     });
   });
 });

--- a/src/stats/operations/operations.service.spec.ts
+++ b/src/stats/operations/operations.service.spec.ts
@@ -55,13 +55,13 @@ describe('OperationsService', () => {
     transaction = {
       type: 1,
       id: 'fake_transaction',
-      transfers: [{
-        recipient: 'some_recipient',
-      }, {
-        recipient: 'some_recipient_2',
-      }, {
-        recipient: 'some_recipient_3',
-      }],
+      timestamp: new Date('2020-12-04 00:00:00+00:00').getTime(),
+      transfers: [
+        {recipient: 'some_recipient'},
+        {recipient: 'some_recipient_2'},
+        {recipient: 'some_recipient_3'},
+      ],
+      anchors: ['a', 'b'],
     } as Transaction;
   });
 
@@ -91,7 +91,9 @@ describe('OperationsService', () => {
 
       await operationsService.incrOperationStats(transaction);
 
-      expect(spies.storage.incrOperationStats.mock.calls.length).toBe(3);
+      expect(spies.storage.incrOperationStats.mock.calls.length).toBe(1);
+      expect(spies.storage.incrOperationStats.mock.calls[0][0]).toBe(18600);
+      expect(spies.storage.incrOperationStats.mock.calls[0][1]).toBe(3);
 
       expect(spies.logger.debug.mock.calls.length).toBe(1);
       expect(spies.logger.debug.mock.calls[0][0])
@@ -121,12 +123,13 @@ describe('OperationsService', () => {
 
       await operationsService.incrOperationStats(transaction);
 
-      expect(spies.anchor.getAnchorHashes.mock.calls.length).toBe(1);
-      expect(spies.storage.incrOperationStats.mock.calls.length).toBe(2);
+      expect(spies.storage.incrOperationStats.mock.calls.length).toBe(1);
+      expect(spies.storage.incrOperationStats.mock.calls[0][0]).toBe(18600);
+      expect(spies.storage.incrOperationStats.mock.calls[0][1]).toBe(2);
       expect(spies.transaction.getIdentifiersByType.mock.calls.length).toBe(1);
 
       expect(spies.logger.debug.mock.calls.length).toBe(1);
-      expect(spies.logger.debug.mock.calls[0][0]).toBe(`operation stats: 2 anchors: increase stats: ${transaction.id}`);
+      expect(spies.logger.debug.mock.calls[0][0]).toBe(`increase operation stats by 2: ${transaction.id}`);
     });
   });
 });

--- a/src/stats/operations/operations.service.ts
+++ b/src/stats/operations/operations.service.ts
@@ -23,10 +23,10 @@ export class OperationsService {
     const identifiers = this.transactionService.getIdentifiersByType(transaction.type);
 
     const iterations = identifiers.indexOf('anchor') >= 0
-      ? Math.min(this.anchorService.getAnchorHashes(transaction).length, 1)
+      ? Math.max(transaction.anchors.length, 1)
       : (transaction.transfers?.length || 1);
 
-    this.logger.debug(`operation stats: ${iterations} transfers: increase stats: ${transaction.id}`);
+    this.logger.debug(`increase operation stats by ${iterations}: ${transaction.id}`);
 
     await this.storage.incrOperationStats(Math.floor(transaction.timestamp / 86400000), iterations);
   }

--- a/src/stats/operations/operations.service.ts
+++ b/src/stats/operations/operations.service.ts
@@ -15,31 +15,19 @@ export class OperationsService {
     private readonly transactionService: TransactionService,
   ) { }
 
-  async getOperationStats(): Promise<string> {
-    return this.storage.getOperationStats();
+  async getOperationStats(from: number, to: number): Promise<{ period: string; count: number }[]> {
+    return this.storage.getOperationStats(from, to);
   }
 
   async incrOperationStats(transaction: Transaction): Promise<void> {
     const identifiers = this.transactionService.getIdentifiersByType(transaction.type);
 
-    if (identifiers.indexOf('anchor') >= 0) {
-      const anchorHashes = this.anchorService.getAnchorHashes(transaction);
-
-      this.logger.debug(`operation stats: ${anchorHashes.length} anchors: increase stats: ${transaction.id}`);
-
-      anchorHashes.forEach(async hash => {
-        await this.storage.incrOperationStats();
-      });
-
-      return;
-    }
-
-    const iterations = transaction.transfers?.length || 1;
+    const iterations = identifiers.indexOf('anchor') >= 0
+      ? Math.min(this.anchorService.getAnchorHashes(transaction).length, 1)
+      : (transaction.transfers?.length || 1);
 
     this.logger.debug(`operation stats: ${iterations} transfers: increase stats: ${transaction.id}`);
 
-    for (let index = 0; index < iterations; index++) {
-      await this.storage.incrOperationStats();
-    }
+    await this.storage.incrOperationStats(Math.floor(transaction.timestamp / 86400000), iterations);
   }
 }

--- a/src/stats/stats.controller.ts
+++ b/src/stats/stats.controller.ts
@@ -44,7 +44,7 @@ export class StatsController {
   @Get('/operations/:from/:to')
   @ApiOperation({ summary: 'Get the operation count per day' })
   @ApiResponse({ status: 200 })
-  @ApiResponse({ status: 400, description: 'failed to retrieve operation stats' })
+  @ApiResponse({ status: 400, description: 'invalid period range given' })
   async getOperationStats(@Req() req: Request, @Res() res: Response): Promise<Response> {
     try {
       const {from, to} = this.periodFromReq(req);
@@ -52,7 +52,7 @@ export class StatsController {
 
       res.status(200).json(stats);
     } catch (e) {
-      return res.status(400).send(e);
+      return res.status(400).send({error: e.message});
     }
   }
 

--- a/src/storage/interfaces/storage.interface.ts
+++ b/src/storage/interfaces/storage.interface.ts
@@ -4,7 +4,7 @@ export interface StorageInterface {
   getMultipleValues(keys: string[]): Promise<string[]>;
   setValue(key: string, value: string): Promise<void>;
   delValue(key: string): Promise<void>;
-  incrValue(key: string): Promise<void>;
+  incrValue(key: string, amount?: number): Promise<void>;
   addObject(key: string, value: object): Promise<void>;
   setObject(key: string, value: object): Promise<void>;
   getObject(key: string): Promise<object>;

--- a/src/storage/storage.service.spec.ts
+++ b/src/storage/storage.service.spec.ts
@@ -483,10 +483,10 @@ describe('StorageService', () => {
 
           expect(getMultipleValues.mock.calls.length).toBe(1);
           expect(getMultipleValues.mock.calls[0][0]).toEqual([
-            `lto:stats:transactions:18600`,
-            `lto:stats:transactions:18601`,
-            `lto:stats:transactions:18602`,
-            `lto:stats:transactions:18603`,
+            `lto:stats:operations:18600`,
+            `lto:stats:operations:18601`,
+            `lto:stats:operations:18602`,
+            `lto:stats:operations:18603`,
           ]);
         });
       });

--- a/src/storage/storage.service.spec.ts
+++ b/src/storage/storage.service.spec.ts
@@ -461,22 +461,33 @@ describe('StorageService', () => {
         test('should increase the value of operation stats', async () => {
           const incrValue = jest.spyOn(redisStorageService, 'incrValue').mockImplementation(async () => {});
 
-          await storageService.incrOperationStats();
+          await storageService.incrOperationStats(800, 5);
 
           expect(incrValue.mock.calls.length).toBe(1);
-          expect(incrValue.mock.calls[0][0]).toBe(`lto:stats:operations`);
+          expect(incrValue.mock.calls[0][0]).toBe(`lto:stats:operations:800`);
+          expect(incrValue.mock.calls[0][1]).toBe(5);
         });
       });
 
       describe('getOperationStats()', () => {
         test('should fetch the value of operation stats', async () => {
-          const getValue = jest.spyOn(redisStorageService, 'getValue').mockImplementation(async () => '15');
+          const getMultipleValues = jest.spyOn(redisStorageService, 'getMultipleValues')
+              .mockImplementation(async () => ['300', '329', '402', '293']);
 
-          const result = await storageService.getOperationStats();
+          expect(await storageService.getOperationStats(18600, 18603)).toEqual([
+            { period: '2020-12-04 00:00:00', count: 300 },
+            { period: '2020-12-05 00:00:00', count: 329 },
+            { period: '2020-12-06 00:00:00', count: 402 },
+            { period: '2020-12-07 00:00:00', count: 293 },
+          ]);
 
-          expect(getValue.mock.calls.length).toBe(1);
-          expect(getValue.mock.calls[0][0]).toBe(`lto:stats:operations`);
-          expect(result).toBe('15');
+          expect(getMultipleValues.mock.calls.length).toBe(1);
+          expect(getMultipleValues.mock.calls[0][0]).toEqual([
+            `lto:stats:transactions:18600`,
+            `lto:stats:transactions:18601`,
+            `lto:stats:transactions:18602`,
+            `lto:stats:transactions:18603`,
+          ]);
         });
       });
     });

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -152,12 +152,20 @@ export class StorageService implements OnModuleInit, OnModuleDestroy {
     return this.storage.incrValue(`lto:stats:transactions:${type}:${day}`);
   }
 
-  async incrOperationStats(): Promise<void> {
-    return this.storage.incrValue(`lto:stats:operations`);
+  async incrOperationStats(day: number, amount = 1): Promise<void> {
+    return this.storage.incrValue(`lto:stats:operations:${day}`, amount);
   }
 
-  async getOperationStats(): Promise<string> {
-    return this.storage.getValue(`lto:stats:operations`);
+  async getOperationStats(from: number, to: number): Promise<{ period: string; count: number }[]> {
+    const length = to - from + 1;
+    const keys = Array.from({ length }, (v, i) => `lto:stats:operations:${from + i}`);
+    const values = await this.storage.getMultipleValues(keys);
+
+    const periods = Array.from({ length }, (v, i) => new Date((from + i) * 86400000));
+    return periods.map((period: Date, index: number) => ({
+      period: this.formatPeriod(period),
+      count: Number(values[index]),
+    }));
   }
 
   async getTxStats(type: string, from: number, to: number): Promise<{ period: string; count: number }[]> {

--- a/src/storage/types/leveldb.storage.service.ts
+++ b/src/storage/types/leveldb.storage.service.ts
@@ -49,7 +49,7 @@ export class LeveldbStorageService implements StorageInterface, OnModuleInit, On
     await this.connection.del(key);
   }
 
-  async incrValue(key: string): Promise<void> {
+  async incrValue(key: string, amount = 1): Promise<void> {
     await this.init();
     await this.connection.incr(key);
   }

--- a/src/storage/types/redis.storage.service.ts
+++ b/src/storage/types/redis.storage.service.ts
@@ -52,9 +52,9 @@ export class RedisStorageService implements StorageInterface, OnModuleInit, OnMo
     return this.connection.del(key);
   }
 
-  async incrValue(key: string): Promise<void> {
+  async incrValue(key: string, amount = 1): Promise<void> {
     await this.init();
-    await this.connection.incr(key);
+    await this.connection.incrby(key, amount);
   }
 
   async addObject(key: string, value: object): Promise<void> {


### PR DESCRIPTION
Use `ANCHOR_BATCH` to start batching anchoring. An anchor tx is sent once every block.

Fixed `/stats/operations` endpoint, so stats are being indexed per day.