### PR TITLE
Fix memory leak

### DIFF
--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -4,6 +4,9 @@
   "node": {
     "url": "https://testnet.lto.network/"
   },
+  "log": {
+    "level": "debug"
+  },
   "transaction": {
     "indexing": true
   },

--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -4,15 +4,19 @@
   "node": {
     "url": "https://testnet.lto.network/"
   },
-  "log": {
-    "level": "debug"
-  },
-  "starting_block": 1600000,
   "transaction": {
     "indexing": true
   },
   "anchor": {
     "indexing": "all"
+  },
+  "association": {
+    "indexing": "all"
+  },
+  "stats": {
+    "operations": true,
+    "transactions": true,
+    "supply": true
   },
   "cross_chain": {
     "eip155": {

--- a/src/index/index-monitor.service.ts
+++ b/src/index/index-monitor.service.ts
@@ -141,6 +141,8 @@ export class IndexMonitorService {
 
     let position = 0;
 
+    await this.indexer.indexBlock(block.height);
+
     for (const transaction of block.transactions) {
       await this.processTransaction(transaction, block.height, position);
       position++;

--- a/src/index/index.service.spec.ts
+++ b/src/index/index.service.spec.ts
@@ -45,9 +45,8 @@ describe('IndexService', () => {
       const transaction = { id: 'fake_transaction', type: 1, sender: 'fake_sender' };
       await indexService.index({ transaction: transaction as any, blockHeight: 1, position: 0});
 
-      expect(spies.emitter.emit.mock.calls.length).toBe(2);
-      expect(spies.emitter.emit.mock.calls[0][0]).toBe('IndexBlock');
-      expect(spies.emitter.emit.mock.calls[1][0]).toBe('IndexTransaction');
+      expect(spies.emitter.emit.mock.calls.length).toBe(1);
+      expect(spies.emitter.emit.mock.calls[0][0]).toBe('IndexTransaction');
     });
 
     test('should index the anchor transaction', async () => {

--- a/src/index/index.service.ts
+++ b/src/index/index.service.ts
@@ -16,19 +16,22 @@ export class IndexService {
   ) { }
 
   /**
+   * Index a new block. Should be called before indexing individual txs.
+   *
+   * @param height
+   */
+  async indexBlock(height: number) {
+    this.txCache = [];
+    this.event.emit(IndexEvent.IndexBlock, height);
+  }
+
+  /**
    * Index transaction, returns boolean based on whether or not transaction was successful
    * Transaction may be skipped if its already processed
    *
    * @param index
    */
   async index(index: IndexDocumentType): Promise<boolean> {
-    if (this.lastBlock !== index.blockHeight) {
-      this.txCache = [];
-      this.event.emit(IndexEvent.IndexBlock, index.blockHeight);
-    }
-
-    this.lastBlock = index.blockHeight;
-
     if (this.txCache.indexOf(index.transaction.id) > -1) {
       // transaction is already processed
       return false;
@@ -39,5 +42,7 @@ export class IndexService {
     this.logger.debug(`index-service: emitting index event`);
 
     this.event.emit(IndexEvent.IndexTransaction, index);
+
+    return true;
   }
 }

--- a/src/leveldb/classes/leveldb.connection.ts
+++ b/src/leveldb/classes/leveldb.connection.ts
@@ -6,10 +6,24 @@ import AwaitLock from 'await-lock';
  * @todo Move this logic into leveldb.storage.service
  */
 export class LeveldbConnection {
-  private incrLock: AwaitLock;
+  private incrLock: {[key: string]: AwaitLock} = {};
 
-  constructor(private connection: level.Level) {
-    this.incrLock = new AwaitLock();
+  constructor(private connection: level.Level) {}
+
+  private async lock(key: string) {
+    if (!this.incrLock.hasOwnProperty(key)) {
+      this.incrLock[key] = new AwaitLock();
+    }
+
+    return await this.incrLock[key].acquireAsync();
+  }
+
+  private unlock(key: string) {
+    this.incrLock[key].release();
+
+    if (!this.incrLock[key].acquired) {
+      delete this.incrLock[key];
+    }
   }
 
   get(key: level.KeyType): Promise<string> {
@@ -28,7 +42,7 @@ export class LeveldbConnection {
   }
 
   async add(key: level.KeyType, value: string): Promise<string> {
-    await this.incrLock.acquireAsync();
+    await this.lock(key);
 
     try {
       const existing = await this.get(key);
@@ -38,7 +52,7 @@ export class LeveldbConnection {
       const result = await this.connection.put(key, value);
       return result;
     } finally {
-      this.incrLock.release();
+      this.unlock(key);
     }
   }
 
@@ -51,14 +65,14 @@ export class LeveldbConnection {
   }
 
   async incr(key, amount = 1): Promise<string> {
-    await this.incrLock.acquireAsync();
+    await this.lock(key);
 
     try {
       const count = Number(await this.get(key));
       const result = await this.set(key, String(count + amount));
       return result;
     } finally {
-      this.incrLock.release();
+      this.unlock(key);
     }
   }
 

--- a/src/leveldb/leveldb-listener.service.ts
+++ b/src/leveldb/leveldb-listener.service.ts
@@ -1,0 +1,29 @@
+import { IndexEvent, IndexEventsReturnType } from '../index/index.events';
+import { EmitterService } from '../emitter/emitter.service';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '../config/config.service';
+import { LeveldbService } from './leveldb.service';
+
+@Injectable()
+export class LeveldbListenerService implements OnModuleInit {
+  constructor(
+    private readonly indexEmitter: EmitterService<IndexEventsReturnType>,
+    private readonly config: ConfigService,
+    private readonly leveldbService: LeveldbService,
+  ) { }
+
+  async onModuleInit() {
+    if (this.config.getStorageType() !== 'leveldb') {
+      return;
+    }
+
+    await this.onIndexBlock();
+  }
+
+  async onIndexBlock() {
+    this.indexEmitter.on(
+      IndexEvent.IndexBlock,
+      () => this.leveldbService.flush(),
+    );
+  }
+}

--- a/src/leveldb/leveldb.module.ts
+++ b/src/leveldb/leveldb.module.ts
@@ -3,13 +3,16 @@ import { leveldbProviders } from './leveldb.providers';
 import { LeveldbService } from './leveldb.service';
 import { LoggerModule } from '../logger/logger.module';
 import { ConfigModule } from '../config/config.module';
+import { LeveldbListenerService } from './leveldb-listener.service';
+import { EmitterModule } from '../emitter/emitter.module';
 
 export const LevelModuleConfig = {
-  imports: [LoggerModule, ConfigModule],
+  imports: [LoggerModule, ConfigModule, EmitterModule],
   controllers: [],
   providers: [
     ...leveldbProviders,
     LeveldbService,
+    LeveldbListenerService,
   ],
   exports: [
     ...leveldbProviders,

--- a/src/leveldb/leveldb.providers.ts
+++ b/src/leveldb/leveldb.providers.ts
@@ -1,5 +1,5 @@
 import level from 'level';
- import { LEVEL } from '../constants';
+import { LEVEL } from '../constants';
 
 export const leveldbProviders = [
   {

--- a/src/leveldb/leveldb.service.ts
+++ b/src/leveldb/leveldb.service.ts
@@ -33,8 +33,16 @@ export class LeveldbService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  async flush(): Promise<void> {
+    if (this.connection) {
+      this.logger.debug(`level: flush`);
+      await this.connection.flush();
+    }
+  }
+
   async close() {
     if (this.connection) {
+      this.logger.debug(`level: close`);
       await this.connection.close();
     }
   }

--- a/src/stats/operations/operations.service.spec.ts
+++ b/src/stats/operations/operations.service.spec.ts
@@ -53,7 +53,7 @@ describe('OperationsService', () => {
     operationsService = module.get<OperationsService>(OperationsService);
 
     transaction = {
-      type: 1,
+      type: 11,
       id: 'fake_transaction',
       timestamp: new Date('2020-12-04 00:00:00+00:00').getTime(),
       transfers: [
@@ -112,6 +112,9 @@ describe('OperationsService', () => {
       const spies = spy();
 
       spies.transaction.getIdentifiersByType.mockImplementation(() => ['anchor', 'all']);
+      // @ts-ignore
+      // noinspection JSConstantReassignment
+      transaction.type = 15;
 
       await operationsService.incrOperationStats(transaction);
 

--- a/src/stats/operations/operations.service.ts
+++ b/src/stats/operations/operations.service.ts
@@ -22,9 +22,10 @@ export class OperationsService {
   async incrOperationStats(transaction: Transaction): Promise<void> {
     const identifiers = this.transactionService.getIdentifiersByType(transaction.type);
 
-    const iterations = identifiers.indexOf('anchor') >= 0
-      ? Math.max(transaction.anchors.length, 1)
-      : (transaction.transfers?.length || 1);
+    const iterations =
+        transaction.type === 15 ? Math.max(transaction.anchors.length, 1) :
+        transaction.type === 11 ? transaction.transfers.length :
+        1;
 
     this.logger.debug(`increase operation stats by ${iterations}: ${transaction.id}`);
 


### PR DESCRIPTION
Problem: New transactions are pushed quicker than the operations that can be written to leveldb. This causes the backlog to run up, ultimately making indexer run out of memory.

For leveldb cache all modified values.
Flush to leveldb in a batch transaction, once per block.