### PR TITLE
Fix anchoring

### DIFF
--- a/src/anchor/anchor.service.ts
+++ b/src/anchor/anchor.service.ts
@@ -36,14 +36,13 @@ export class AnchorService {
       const isSenderTrustNetwork = Object.keys(senderRoles.roles).length > 0;
 
       if (!isSenderTrustNetwork) {
-        this.logger.debug(`anchor: Sender is not part of trust network`);
         return;
       }
     }
 
     const hashes = this.getAnchorHashes(transaction);
 
-    hashes.forEach(async hexHash => {
+    for (const hexHash of hashes) {
       this.logger.debug(`anchor: save hash ${hexHash} with transaction ${transaction.id}`);
 
       await this.storage.saveAnchor(hexHash, {
@@ -51,7 +50,7 @@ export class AnchorService {
         blockHeight,
         position,
       });
-    });
+    }
   }
 
   public getAnchorHashes(transaction: Transaction): string[] {
@@ -74,6 +73,8 @@ export class AnchorService {
         hashes.push(hexHash);
       });
     }
+
+    console.log(hashes);
 
     return hashes;
   }

--- a/src/anchor/anchor.service.ts
+++ b/src/anchor/anchor.service.ts
@@ -74,8 +74,6 @@ export class AnchorService {
       });
     }
 
-    console.log(hashes);
-
     return hashes;
   }
 }

--- a/src/associations/associations.service.spec.ts
+++ b/src/associations/associations.service.spec.ts
@@ -165,8 +165,6 @@ describe('AssociationsService', () => {
       expect(spies.trust.getRolesFor.mock.calls.length).toBe(1);
       expect(spies.trust.getRolesFor.mock.calls[0][0]).toBe('3JuijVBB7NCwCz2Ae5HhCDsqCXzeBLRTyeL');
 
-      expect(spies.logger.debug.mock.calls[0][0]).toBe('association-service: Sender is not part of trust network');
-
       expect(spies.storage.saveAssociation.mock.calls.length).toBe(0);
     });
 

--- a/src/associations/associations.service.ts
+++ b/src/associations/associations.service.ts
@@ -45,7 +45,6 @@ export class AssociationsService {
       const isSenderTrustNetwork = Object.keys(senderRoles.roles).length > 0;
 
       if (!isSenderTrustNetwork) {
-        this.logger.debug(`association-service: Sender is not part of trust network`);
         return;
       }
     }

--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -7,19 +7,20 @@
   "log": {
     "level": "debug"
   },
-  "starting_block": 1972742,
+  "starting_block": -1,
   "transaction": {
     "indexing": false
   },
   "anchor": {
-    "indexing": "none"
+    "indexing": "all",
+    "batch": true
   },
   "association": {
     "indexing": "none"
   },
   "stats": {
-    "operations": true,
-    "transactions": true,
+    "operations": false,
+    "transactions": false,
     "supply": false
   },
   "identity": {

--- a/src/hash/hash-listener.service.ts
+++ b/src/hash/hash-listener.service.ts
@@ -16,10 +16,10 @@ export class HashListenerService implements OnModuleInit {
 
   onModuleInit() {
     if (!this.config.isAnchorBatched()) {
-      this.logger.debug(`hash-listener: Not batching anchors`);
       return;
     }
 
+    this.logger.debug(`hash-listener: Batching anchors`);
     this.onIndexBlock();
   }
 

--- a/src/hash/hash.controller.ts
+++ b/src/hash/hash.controller.ts
@@ -52,7 +52,7 @@ export class HashController {
       const chainpoint = await this.hash.anchor(hash, encoding);
 
       if (!chainpoint) {
-        res.status(202);
+        res.status(202).end();
       } else {
         res.status(200).json({chainpoint});
       }

--- a/src/index/index-monitor.service.spec.ts
+++ b/src/index/index-monitor.service.spec.ts
@@ -226,8 +226,7 @@ describe('IndexMonitorService', () => {
       expect(spies.node.getLastBlockHeight.mock.calls.length).toBe(1);
       expect(spies.node.getBlock.mock.calls.length).toBe(0);
       expect(spies.node.getBlocks.mock.calls.length).toBe(1);
-      expect(spies.node.getBlocks.mock.calls[0][0]).toEqual(100);
-      expect(spies.node.getBlocks.mock.calls[0][1]).toEqual(100);
+      expect(spies.node.getBlocks.mock.calls[0]).toEqual([99, 100]);
 
       expect(spies.storage.saveProcessingHeight.mock.calls.length).toBe(1);
       expect(spies.storage.saveProcessingHeight.mock.calls[0][0]).toBe(100);

--- a/src/index/index.service.spec.ts
+++ b/src/index/index.service.spec.ts
@@ -27,7 +27,6 @@ describe('IndexService', () => {
 
     indexService = module.get<IndexService>(IndexService);
     emitterService = module.get<EmitterService<IndexEventsReturnType>>(EmitterService);
-
   });
 
   afterEach(async () => {
@@ -39,6 +38,17 @@ describe('IndexService', () => {
   });
 
   describe('index()', () => {
+    beforeEach(() => {
+      indexService.lastBlock = {
+        height: 1,
+        burnedFees: 0,
+        timestamp: 1,
+        generator: '2s',
+        transactionCount: 0,
+        transactions: [],
+      };
+    });
+
     test('should ignore genesis transactions', async () => {
       const spies = spy();
 
@@ -50,21 +60,23 @@ describe('IndexService', () => {
     });
 
     test('should index the anchor transaction', async () => {
-      indexService.lastBlock = 1; // Don't emit IndexBlock
       const spies = spy();
 
-      const type = 'anchor';
-      const transaction = { id: 'fake_transaction', type: 12, sender: 'fake_sender' };
-      await indexService.indexTx({ transaction: transaction as any, blockHeight: 1, position: 0});
+      const transaction = {id: 'fake_transaction', type: 15, sender: 'fake_sender'};
+      await indexService.indexTx({transaction: transaction as any, blockHeight: 1, position: 0});
 
       expect(spies.emitter.emit.mock.calls.length).toBe(1);
-      // expect(spies.storage.indexTx.mock.calls[0][0]).toBe(type);
-      // expect(spies.storage.indexTx.mock.calls[0][1]).toBe(transaction.sender);
-      // expect(spies.storage.indexTx.mock.calls[0][2]).toBe(transaction.id);
     });
 
-    test.skip('should skip index if an tx is indexed twice', () => {
+    test('should skip index if an tx is indexed twice', async () => {
+      const spies = spy();
 
+      indexService.txCache.push('fake_transaction');
+
+      const transaction = {id: 'fake_transaction', type: 15, sender: 'fake_sender'};
+      await indexService.indexTx({transaction: transaction as any, blockHeight: 1, position: 0});
+
+      expect(spies.emitter.emit.mock.calls.length).toBe(0);
     });
   });
 });

--- a/src/index/index.service.ts
+++ b/src/index/index.service.ts
@@ -8,7 +8,7 @@ import { Block } from '../transaction/interfaces/block.interface';
 @Injectable()
 export class IndexService {
 
-  public lastBlock: number;
+  public lastBlock: Block;
   public txCache: string[] = [];
 
   constructor(
@@ -22,10 +22,18 @@ export class IndexService {
    * @param block
    */
   async indexBlock(block: Block) {
-    this.txCache = [];
+    if (!this.lastBlock) {
+      this.lastBlock = block;
+      return;
+    }
 
-    this.logger.debug(`index-service: emitting index event for block ${block.height}`);
-    this.event.emit(IndexEvent.IndexBlock, block);
+    if (this.lastBlock.height !== block.height) {
+      this.logger.debug(`index-service: emitting index event for block ${this.lastBlock.height}`);
+      this.event.emit(IndexEvent.IndexBlock, this.lastBlock);
+
+      this.lastBlock = block;
+      this.txCache = [];
+    }
   }
 
   /**

--- a/src/node/node.service.ts
+++ b/src/node/node.service.ts
@@ -198,8 +198,6 @@ export class NodeService {
     targetHash;
     anchors;
   } | null> {
-    this.logger.debug(`hash: starting anchoring '${hash}' as '${encoding}'`);
-
     try {
       const senderAddress = await this.getNodeWallet();
       const base58Hash = this.encoder.base58Encode(this.encoder.decode(hash, encoding));
@@ -218,10 +216,13 @@ export class NodeService {
     }
   }
 
-  async anchorAll(...hashes: string[]): Promise<void> {
+  async anchorAll(...hashes: string[]): Promise<string> {
     try {
       const senderAddress = await this.getNodeWallet();
-      await this.createAnchorTransaction(senderAddress, ...hashes);
+      const txId = await this.createAnchorTransaction(senderAddress, ...hashes);
+
+      this.logger.debug(`hash: anchored ${hashes.length} hashes with tx ${txId}`);
+      return txId;
     } catch (e) {
       this.logger.error(`hash: failed anchoring ${hashes.length} hashes`);
       throw e;


### PR DESCRIPTION
Fix batch anchoring.

Fix indexing txs. Wasn't working properly in v1.3.2 as NG was ignored.
Block is indexed after new block is minted