### PR TITLE
Specify sender when verifying anchors

### DIFF
--- a/src/anchor/mapped-anchor.service.spec.ts
+++ b/src/anchor/mapped-anchor.service.spec.ts
@@ -65,7 +65,7 @@ describe('MappedAnchorService', () => {
           '2c67899b31a40620b0760035720a9cabd7f414c6da3db561461b1e48fe26cb08',
       );
       expect(spies.storage.saveMappedAnchor.mock.calls[0][2]).toMatchObject({
-        anchor: '2c67899b31a40620b0760035720a9cabd7f414c6da3db561461b1e48fe26cb08',
+        hash: '2c67899b31a40620b0760035720a9cabd7f414c6da3db561461b1e48fe26cb08',
         id: 'fake_transaction',
         sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
         blockHeight: 1,

--- a/src/anchor/mapped-anchor.service.spec.ts
+++ b/src/anchor/mapped-anchor.service.spec.ts
@@ -48,6 +48,7 @@ describe('MappedAnchorService', () => {
       const transaction = {
         id: 'fake_transaction',
         type: 22,
+        sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
         anchors: {
           GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn: '3zLWTHPNkmDsCRi2kZqFXFSBnTYykz13gHLezU4p6zmu',
         },
@@ -60,9 +61,13 @@ describe('MappedAnchorService', () => {
       expect(spies.storage.saveMappedAnchor.mock.calls[0][0]).toBe(
           'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
       );
-      expect(spies.storage.saveMappedAnchor.mock.calls[0][1]).toMatchObject({
+      expect(spies.storage.saveMappedAnchor.mock.calls[0][1]).toBe(
+          '2c67899b31a40620b0760035720a9cabd7f414c6da3db561461b1e48fe26cb08',
+      );
+      expect(spies.storage.saveMappedAnchor.mock.calls[0][2]).toMatchObject({
         anchor: '2c67899b31a40620b0760035720a9cabd7f414c6da3db561461b1e48fe26cb08',
         id: 'fake_transaction',
+        sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
         blockHeight: 1,
         position: 0,
       });

--- a/src/anchor/mapped-anchor.service.ts
+++ b/src/anchor/mapped-anchor.service.ts
@@ -40,7 +40,7 @@ export class MappedAnchorService {
       this.logger.debug(`mapped-anchor: save ${hexKey}:${hexValue} with transaction ${transaction.id}`);
 
       await this.storage.saveMappedAnchor(hexKey, hexValue, {
-        anchor: hexValue,
+        hash: hexValue,
         id: transaction.id,
         sender: transaction.sender,
         blockHeight,

--- a/src/anchor/mapped-anchor.service.ts
+++ b/src/anchor/mapped-anchor.service.ts
@@ -39,9 +39,10 @@ export class MappedAnchorService {
 
       this.logger.debug(`mapped-anchor: save ${hexKey}:${hexValue} with transaction ${transaction.id}`);
 
-      await this.storage.saveMappedAnchor(hexKey, {
+      await this.storage.saveMappedAnchor(hexKey, hexValue, {
         anchor: hexValue,
         id: transaction.id,
+        sender: transaction.sender,
         blockHeight,
         position,
       });

--- a/src/config/data/development.config.json
+++ b/src/config/data/development.config.json
@@ -5,7 +5,7 @@
     "url": "https://testnet.lto.network"
   },
   "log": {
-    "level": "debug"
+    "level": "info"
   },
   "starting_block": -1
 }

--- a/src/hash/hash.controller.spec.ts
+++ b/src/hash/hash.controller.spec.ts
@@ -27,7 +27,7 @@ describe('HashController', () => {
 
   function spy() {
     const hash = {
-      anchor: jest.spyOn(hashService, 'anchor').mockImplementation(async () => chainpoint),
+      hash: jest.spyOn(hashService, 'anchor').mockImplementation(async () => chainpoint),
     };
 
     const node = {
@@ -65,9 +65,9 @@ describe('HashController', () => {
       expect(res.header['content-type']).toBe('application/json; charset=utf-8');
       expect(res.body).toEqual({ chainpoint });
 
-      expect(spies.hash.anchor.mock.calls.length).toBe(1);
-      expect(spies.hash.anchor.mock.calls[0][0]).toBe(hash);
-      expect(spies.hash.anchor.mock.calls[0][1]).toBe('hex');
+      expect(spies.hash.hash.mock.calls.length).toBe(1);
+      expect(spies.hash.hash.mock.calls[0][0]).toBe(hash);
+      expect(spies.hash.hash.mock.calls[0][1]).toBe('hex');
     });
 
     test('should anchor hash to the blockchain when auth is enabled and given', async () => {
@@ -85,9 +85,9 @@ describe('HashController', () => {
       expect(res.header['content-type']).toBe('application/json; charset=utf-8');
       expect(res.body).toEqual({ chainpoint });
 
-      expect(spies.hash.anchor.mock.calls.length).toBe(1);
-      expect(spies.hash.anchor.mock.calls[0][0]).toBe(hash);
-      expect(spies.hash.anchor.mock.calls[0][1]).toBe('hex');
+      expect(spies.hash.hash.mock.calls.length).toBe(1);
+      expect(spies.hash.hash.mock.calls[0][0]).toBe(hash);
+      expect(spies.hash.hash.mock.calls[0][1]).toBe('hex');
     });
 
     test('should return an unauthorized when auth is enabled and not given', async () => {

--- a/src/hash/hash.controller.ts
+++ b/src/hash/hash.controller.ts
@@ -51,11 +51,10 @@ export class HashController {
     try {
       const chainpoint = await this.hash.anchor(hash, encoding);
 
-      if (!chainpoint) {
+      if (!chainpoint)
         res.status(202).end();
-      } else {
+      else
         res.status(200).json({chainpoint});
-      }
     } catch (e) {
       this.logger.error(`hash-controller: failed to anchor '${e}'`, { stack: e.stack });
 

--- a/src/hash/hash.service.spec.ts
+++ b/src/hash/hash.service.spec.ts
@@ -91,31 +91,79 @@ describe('HashService', () => {
   });
 
   describe('verifyMappedAnchors()', () => {
-    test('return verified is true if all anchors match', async () => {
+    let stored;
+    let getMappedAnchorsByKey;
+
+    beforeAll(() => {
+      stored = {
+        '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': [ // 2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc
+          {
+            anchor: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b', // 8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG
+            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+          },
+          {
+            anchor: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', // 3yMApqCuCjXDWPrbjfR5mjCPTHqFG8Pux1TxQrEM35jj
+            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+          },
+        ],
+        '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': [ // 4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc
+          {
+            anchor: 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35', // FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg
+            sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+          },
+        ],
+        '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': [ // 28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd
+          {
+            anchor: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', // GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn
+            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+          },
+        ],
+      };
+    });
+
+    beforeEach(() => {
+      getMappedAnchorsByKey = jest.spyOn(storageService, 'getMappedAnchorsByKey')
+          .mockImplementation(async hash => stored[hash] || []);
+    });
+
+    test('return verified is true if all anchors match as first entry', async () => {
       const pairs = {
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
         '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
-        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf',
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       };
 
-      const stored = {
-        '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': { anchor: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b' },
-        '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': { anchor: 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35' },
-        '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': { anchor: '4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce' },
-      };
+      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
 
-      const getMappedAnchor = jest.spyOn(storageService, 'getMappedAnchor')
-          .mockImplementation(async hash => stored[hash] || {});
+      expect(getMappedAnchorsByKey.mock.calls.length).toBe(4);
+      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
+      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
+      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
+      expect(getMappedAnchorsByKey.mock.calls[3][0]).toBe('d5ce2b19fbda14a25deac948154722f33efd37b369a32be8f03ec2be8ef7d3a5');
 
-      const result = await hashService.verifyMappedAnchors(pairs, 'base58');
-
-      expect(getMappedAnchor.mock.calls.length).toBe(3);
-      expect(getMappedAnchor.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
-      expect(getMappedAnchor.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
-      expect(getMappedAnchor.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
-
-      expect(result.anchors).toEqual(pairs);
-      expect(result.verified).toBe(true);
+      expect(anchors).toEqual({
+        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': [
+          {
+            anchor: '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
+            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+          },
+        ],
+        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': [
+          {
+            anchor: 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
+            sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+          },
+        ],
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': [
+          {
+            anchor: 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
+            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+          },
+        ],
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': [],
+      });
+      expect(verified).toBe(true);
     });
 
     test('return verified is false if one anchors is not found', async () => {
@@ -125,21 +173,13 @@ describe('HashService', () => {
         '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf',
       };
 
-      const stored = {
-        '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': { anchor: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b' },
-        '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': { },
-        '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': { anchor: '4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce' },
-      };
-
-      const getMappedAnchor = jest.spyOn(storageService, 'getMappedAnchor')
-          .mockImplementation(async hash => stored[hash] || {});
-
       const result = await hashService.verifyMappedAnchors(pairs, 'base58');
 
-      expect(getMappedAnchor.mock.calls.length).toBe(3);
-      expect(getMappedAnchor.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
-      expect(getMappedAnchor.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
-      expect(getMappedAnchor.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
+      expect(getMappedAnchorsByKey.mock.calls.length).toBe(4);
+      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
+      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
+      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
+      expect(getMappedAnchorsByKey.mock.calls[3][0]).toBe('d5ce2b19fbda14a25deac948154722f33efd37b369a32be8f03ec2be8ef7d3a5');
 
       expect(result.anchors).toEqual({
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
@@ -156,21 +196,15 @@ describe('HashService', () => {
         '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf',
       };
 
-      const stored = {
-        '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': { anchor: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b' },
-        '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': { anchor: 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35' },
-        '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': { anchor: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' },
-      };
-
-      const getMappedAnchor = jest.spyOn(storageService, 'getMappedAnchor')
+      const getMappedAnchorsByKey = jest.spyOn(storageService, 'getMappedAnchorsByKey')
           .mockImplementation(async hash => stored[hash] || {});
 
       const result = await hashService.verifyMappedAnchors(pairs, 'base58');
 
-      expect(getMappedAnchor.mock.calls.length).toBe(3);
-      expect(getMappedAnchor.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
-      expect(getMappedAnchor.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
-      expect(getMappedAnchor.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
+      expect(getMappedAnchorsByKey.mock.calls.length).toBe(3);
+      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
+      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
+      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
 
       expect(result.anchors).toEqual({
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',

--- a/src/hash/hash.service.spec.ts
+++ b/src/hash/hash.service.spec.ts
@@ -91,40 +91,52 @@ describe('HashService', () => {
   });
 
   describe('verifyMappedAnchors()', () => {
-    let stored;
     let getMappedAnchorsByKey;
 
-    beforeAll(() => {
-      stored = {
-        '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': [ // 2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc
-          {
-            anchor: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b', // 8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG
-            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
-          },
-          {
-            anchor: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae', // 3yMApqCuCjXDWPrbjfR5mjCPTHqFG8Pux1TxQrEM35jj
-            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
-          },
-        ],
-        '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': [ // 4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc
-          {
-            anchor: 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35', // FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg
-            sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
-          },
-        ],
-        '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': [ // 28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd
-          {
-            anchor: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855', // GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn
-            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
-          },
-        ],
-      };
-    });
+    const stored = {
+      '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': [
+        {
+          hash: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b',
+          sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+        },
+        {
+          hash: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
+          sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+        },
+      ],
+      '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': [
+        {
+          hash: 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35',
+          sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+        },
+      ],
+      '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': [
+        {
+          hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+          sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
+        },
+      ],
+    };
+
+    const expectedResult = {
+      '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
+      '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
+      '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
+      'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
+    };
 
     beforeEach(() => {
       getMappedAnchorsByKey = jest.spyOn(storageService, 'getMappedAnchorsByKey')
           .mockImplementation(async hash => stored[hash] || []);
     });
+
+    function assertGetMappedAnchorsByKeyCalls() {
+      expect(getMappedAnchorsByKey.mock.calls.length).toBe(4);
+      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
+      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
+      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
+      expect(getMappedAnchorsByKey.mock.calls[3][0]).toBe('d5ce2b19fbda14a25deac948154722f33efd37b369a32be8f03ec2be8ef7d3a5');
+    }
 
     test('return verified is true if all anchors match as first entry', async () => {
       const pairs = {
@@ -135,34 +147,9 @@ describe('HashService', () => {
       };
 
       const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      assertGetMappedAnchorsByKeyCalls();
 
-      expect(getMappedAnchorsByKey.mock.calls.length).toBe(4);
-      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
-      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
-      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
-      expect(getMappedAnchorsByKey.mock.calls[3][0]).toBe('d5ce2b19fbda14a25deac948154722f33efd37b369a32be8f03ec2be8ef7d3a5');
-
-      expect(anchors).toEqual({
-        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': [
-          {
-            anchor: '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
-            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
-          },
-        ],
-        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': [
-          {
-            anchor: 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
-            sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
-          },
-        ],
-        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': [
-          {
-            anchor: 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
-            sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
-          },
-        ],
-        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': [],
-      });
+      expect(anchors).toEqual(expectedResult);
       expect(verified).toBe(true);
     });
 
@@ -170,48 +157,92 @@ describe('HashService', () => {
       const pairs = {
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
         '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
-        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf',
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': '81u',
       };
 
-      const result = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      assertGetMappedAnchorsByKeyCalls();
 
-      expect(getMappedAnchorsByKey.mock.calls.length).toBe(4);
-      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
-      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
-      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
-      expect(getMappedAnchorsByKey.mock.calls[3][0]).toBe('d5ce2b19fbda14a25deac948154722f33efd37b369a32be8f03ec2be8ef7d3a5');
+      expect(anchors).toEqual(expectedResult);
+      expect(verified).toBe(false);
+    });
 
-      expect(result.anchors).toEqual({
-        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
-        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': null,
-        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf',
-      });
-      expect(result.verified).toBe(false);
+    test('return verified is false if one anchors is not the first', async () => {
+      const pairs = {
+        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '3yMApqCuCjXDWPrbjfR5mjCPTHqFG8Pux1TxQrEM35jj',
+        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
+      };
+
+      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      assertGetMappedAnchorsByKeyCalls();
+
+      expect(anchors).toEqual(expectedResult);
+      expect(verified).toBe(false);
     });
 
     test('return verified is false if one anchors does not match', async () => {
       const pairs = {
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
         '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
-        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf',
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': '81u',
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       };
 
-      const getMappedAnchorsByKey = jest.spyOn(storageService, 'getMappedAnchorsByKey')
-          .mockImplementation(async hash => stored[hash] || {});
+      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      assertGetMappedAnchorsByKeyCalls();
 
-      const result = await hashService.verifyMappedAnchors(pairs, 'base58');
+      expect(anchors).toEqual(expectedResult);
+      expect(verified).toBe(false);
+    });
 
-      expect(getMappedAnchorsByKey.mock.calls.length).toBe(3);
-      expect(getMappedAnchorsByKey.mock.calls[0][0]).toBe('146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1');
-      expect(getMappedAnchorsByKey.mock.calls[1][0]).toBe('34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b');
-      expect(getMappedAnchorsByKey.mock.calls[2][0]).toBe('10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda');
-
-      expect(result.anchors).toEqual({
+    test('return verified is false if an anchor exists which is expected to be null', async () => {
+      const pairs = {
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
         '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
-        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': null,
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
+      };
+
+      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      assertGetMappedAnchorsByKeyCalls();
+
+      expect(anchors).toEqual(expectedResult);
+      expect(verified).toBe(false);
+    });
+
+    test('return verified is true when filtering on sender', async () => {
+      const pairs = {
+        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': {
+          hash: '3yMApqCuCjXDWPrbjfR5mjCPTHqFG8Pux1TxQrEM35jj',
+          sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+        },
+        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': {
+          hash: 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
+          sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+        },
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': {
+          hash: null,
+          sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+        },
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': {
+          hash: null,
+          sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
+        },
+      };
+
+      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      assertGetMappedAnchorsByKeyCalls();
+
+      expect(anchors).toEqual({
+        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '3yMApqCuCjXDWPrbjfR5mjCPTHqFG8Pux1TxQrEM35jj',
+        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': null,
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       });
-      expect(result.verified).toBe(false);
+      expect(verified).toBe(true);
     });
   });
 });

--- a/src/hash/hash.service.spec.ts
+++ b/src/hash/hash.service.spec.ts
@@ -51,9 +51,9 @@ describe('HashService', () => {
       expect(getAnchor.mock.calls[2][0]).toBe('4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce');
 
       expect(result.anchors).toEqual({
-        '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG': true,
-        'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg': true,
-        '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf': true,
+        '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG': 1,
+        'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg': 2,
+        '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf': 3,
       });
       expect(result.verified).toBe(true);
     });
@@ -82,9 +82,9 @@ describe('HashService', () => {
       expect(getAnchor.mock.calls[2][0]).toBe('4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce');
 
       expect(result.anchors).toEqual({
-        '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG': true,
-        'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg': false,
-        '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf': true,
+        '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG': 1,
+        'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg': null,
+        '6FbDRScGruVdATaNWzD51xJkTfYCVwxSZDb7gzqCLzwf': 3,
       });
       expect(result.verified).toBe(false);
     });
@@ -96,29 +96,40 @@ describe('HashService', () => {
     const stored = {
       '146da586036684deee1acba1ae0520a79e7502da8b302dc4b683bd4f88f7c8e1': [
         {
+          id: 1,
           hash: '6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b',
           sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
         },
         {
+          id: 2,
           hash: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae',
           sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
         },
       ],
       '34313fc9e1050a02c7d4931f8312cca75b9f4edef653b34794606526b9ec5a7b': [
         {
+          id: 3,
           hash: 'd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35',
           sender: '3NBYfy8LvDgnsr9qEiWHKD6qP7RMQdb2Uf8',
         },
       ],
       '10d331592917e8ee791c5a01f2cf4bd54de81bf648fd7fd1340aa55b73ce7bda': [
         {
+          id: 4,
           hash: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
           sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
         },
       ],
     };
 
-    const expectedResult = {
+    const expectedAnchors = {
+      '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': 1,
+      '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 3,
+      '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 4,
+      'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
+    };
+
+    const expectedMap = {
       '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '8EjkXVSTxMFjCvNNsTo8RBMDEVQmk7gYkW4SCDuvdsBG',
       '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
       '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': 'GKot5hBsd81kMupNCXHaqbhv3huEbxAFMLnpcX2hniwn',
@@ -146,10 +157,11 @@ describe('HashService', () => {
         'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       };
 
-      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors, map} = await hashService.verifyMappedAnchors(pairs, 'base58');
       assertGetMappedAnchorsByKeyCalls();
 
-      expect(anchors).toEqual(expectedResult);
+      expect(anchors).toEqual(expectedAnchors);
+      expect(map).toEqual(expectedMap);
       expect(verified).toBe(true);
     });
 
@@ -161,10 +173,11 @@ describe('HashService', () => {
         'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': '81u',
       };
 
-      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors, map} = await hashService.verifyMappedAnchors(pairs, 'base58');
       assertGetMappedAnchorsByKeyCalls();
 
-      expect(anchors).toEqual(expectedResult);
+      expect(anchors).toEqual(expectedAnchors);
+      expect(map).toEqual(expectedMap);
       expect(verified).toBe(false);
     });
 
@@ -176,10 +189,11 @@ describe('HashService', () => {
         'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       };
 
-      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors, map} = await hashService.verifyMappedAnchors(pairs, 'base58');
       assertGetMappedAnchorsByKeyCalls();
 
-      expect(anchors).toEqual(expectedResult);
+      expect(anchors).toEqual(expectedAnchors);
+      expect(map).toEqual(expectedMap);
       expect(verified).toBe(false);
     });
 
@@ -191,10 +205,11 @@ describe('HashService', () => {
         'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       };
 
-      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors, map} = await hashService.verifyMappedAnchors(pairs, 'base58');
       assertGetMappedAnchorsByKeyCalls();
 
-      expect(anchors).toEqual(expectedResult);
+      expect(anchors).toEqual(expectedAnchors);
+      expect(map).toEqual(expectedMap);
       expect(verified).toBe(false);
     });
 
@@ -206,10 +221,11 @@ describe('HashService', () => {
         'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
       };
 
-      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors, map} = await hashService.verifyMappedAnchors(pairs, 'base58');
       assertGetMappedAnchorsByKeyCalls();
 
-      expect(anchors).toEqual(expectedResult);
+      expect(anchors).toEqual(expectedAnchors);
+      expect(map).toEqual(expectedMap);
       expect(verified).toBe(false);
     });
 
@@ -233,10 +249,16 @@ describe('HashService', () => {
         },
       };
 
-      const {verified, anchors} = await hashService.verifyMappedAnchors(pairs, 'base58');
+      const {verified, anchors, map} = await hashService.verifyMappedAnchors(pairs, 'base58');
       assertGetMappedAnchorsByKeyCalls();
 
       expect(anchors).toEqual({
+        '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': 2,
+        '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 3,
+        '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': null,
+        'FPcBCxxV4teUiKecPnnzqqunAKEhwNJLckWTWAoaD5oz': null,
+      });
+      expect(map).toEqual({
         '2Nk8JfzQ47wX7XEdkemRJbNTLxC529YwJ92U9g6FyeAc': '3yMApqCuCjXDWPrbjfR5mjCPTHqFG8Pux1TxQrEM35jj',
         '4WjkssnwoTRrTo4xKX8rac1b3zwrGvpy4kgRCsHJ49yc': 'FJKTv1un7qsnyKdwKez7B67JJp3oCU5ntCVXcRsWEjtg',
         '28gJaguAnsUEUMcfzXU6tpCLjhTH2xfg2G3NEHzetmUd': null,

--- a/src/hash/hash.service.ts
+++ b/src/hash/hash.service.ts
@@ -51,24 +51,25 @@ export class HashService
     async verifyAnchors(
         hashes: Array<string>,
         encoding: string,
-    ): Promise<{ verified: boolean, anchors: {[key: string]: boolean} }> {
-        const promises: Array<Promise<[string, boolean]>> = hashes.map(hash => {
+    ): Promise<{ verified: boolean, anchors: {[key: string]: boolean}, txIds: string[] }> {
+        const promises: Array<Promise<[string, string | undefined]>> = hashes.map(hash => {
             const hashHex = this.encoder.hexEncode(this.encoder.decode(hash, encoding));
-            return this.storage.getAnchor(hashHex).then((info: { id: string }) => [hash, !!info.id]);
+            return this.storage.getAnchor(hashHex).then((info: { id: string }) => [hash, info?.id]);
         });
 
-        const result = Object.fromEntries(await Promise.all(promises));
+        const result = await Promise.all(promises);
 
         return {
-            verified: Object.values(result).every(b => b),
-            anchors: result,
+            verified: result.every(([, txId]) => !!txId),
+            anchors: Object.fromEntries(result.map(([hash, txId]) => [hash, !!txId])),
+            txIds: result.map(([, txId]) => txId),
         };
     }
 
     async verifyMappedAnchors(
         hashes: {[key: string]: string|{hash: string, sender?: string|string[]}},
         encoding: string,
-    ): Promise<{ verified: boolean, anchors: {[key: string]: string|null} }> {
+    ): Promise<{ verified: boolean, anchors: {[key: string]: string|null}, txIds: string[]}> {
         const promises = Object.entries(hashes).map(([key, value]) => {
             const keyHex = this.encoder.hexEncode(this.encoder.decode(key, encoding));
             const {hash, sender = null} = typeof value === 'object' && value !== null ? (value as any) : {hash: value};
@@ -80,26 +81,27 @@ export class HashService
         return {
             verified: result.every(({verified}) => verified),
             anchors: Object.fromEntries(result.map(({key, hash}) => [key, hash])),
+            txIds: result.map(({txId}) => txId),
         };
     }
 
     private processMappedAnchor(
-        set: {hash: string, sender: string, timestamp: number, blockHeight: number, position: number}[],
+        set: {hash: string, id: string, sender: string, timestamp: number, blockHeight: number, position: number}[],
         key: string,
         value: string|null,
         encoding: string,
         sender?: string|string[],
-    ): { verified: boolean, key: string, hash: string } {
+    ): { verified: boolean, key: string, hash: string|null, txId: string|null } {
         if (sender) {
             const senders = (typeof sender === 'string') ? [sender] : sender;
             set = set.filter(info => senders.includes(info.sender));
         }
 
-        const {hash: hashHex} = set
+        const {hash: hashHex, id} = set
             .sort((a, b) => b.blockHeight - a.blockHeight || b.position - a.position)
-            [0] || {hash: null};
+            [0] || {hash: null, id: null};
         const hash = hashHex ? this.encoder.encode(this.encoder.hexDecode(hashHex), encoding) : null;
 
-        return { key, verified: hash === value, hash };
+        return { key, verified: hash === value, hash, txId: id };
     }
 }

--- a/src/index/index-monitor.service.ts
+++ b/src/index/index-monitor.service.ts
@@ -29,10 +29,6 @@ export class IndexMonitorService {
       try {
         this.logger.info('index-monitor: starting monitor');
 
-        if (this.started) {
-          return this.logger.warn('index-monitor: monitor already running');
-        }
-
         if (this.config.getRestartSync()) {
           await this.storage.clearProcessHeight();
         }
@@ -43,7 +39,7 @@ export class IndexMonitorService {
         await this.process();
       } catch (e) {
         this.processing = false;
-        this.logger.error(`index-monitor: failed to start monitor: ${e}`);
+        this.logger.error(`index-monitor: ${e}`);
         this.started = false;
         await delay(2000);
       }

--- a/src/leveldb/classes/leveldb.connection.ts
+++ b/src/leveldb/classes/leveldb.connection.ts
@@ -78,15 +78,42 @@ export class LeveldbConnection {
     return value;
   }
 
+  async sadd(key: string, value: string): Promise<any> {
+    return this.add(`${key}!${value}`, value);
+  }
+
+  async srem(key: string, value: string): Promise<any> {
+    return this.add(`${key}!${value}`, value);
+  }
+
+  async sget(key: string): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      const _arr = [];
+
+      return this.connection
+        .createReadStream({
+          gte: key + '!',
+          lte: key + '~',
+        })
+        .on('data', data => {
+          _arr.push(data.value);
+        })
+        .on('error', err => reject(err))
+        .on('close', () => reject({}))
+        .on('end', () => resolve(_arr));
+    });
+  }
+
   async zaddWithScore(key: string, score: string, value: string): Promise<any> {
     const rand = (Math.random() + 1).toString(36).substring(6);
     const newKey = `${key}!${score}:${rand}`;
+
     await this.incrCount(key);
     return this.set(newKey, value);
   }
 
-  async incrCount(key): Promise<void> {
-    await this.incr(`${key}:count`);
+  async incrCount(key): Promise<number> {
+    return Number(await this.incr(`${key}:count`));
   }
 
   async paginate(key: string, limit: number, offset: number): Promise<any> {
@@ -106,15 +133,9 @@ export class LeveldbConnection {
         .on('data', data => {
           _arr.push(data.value);
         })
-        .on('error', err => {
-          reject(err);
-        })
-        .on('close', () => {
-          reject({});
-        })
-        .on('end', () => {
-          resolve(_arr);
-        });
+        .on('error', err => reject(err))
+        .on('close', () => reject({}))
+        .on('end', () => resolve(_arr));
     });
   }
 

--- a/src/leveldb/classes/leveldb.connection.ts
+++ b/src/leveldb/classes/leveldb.connection.ts
@@ -83,7 +83,7 @@ export class LeveldbConnection {
   }
 
   async srem(key: string, value: string): Promise<any> {
-    return this.add(`${key}!${value}`, value);
+    return this.del(`${key}!${value}`);
   }
 
   async sget(key: string): Promise<string[]> {

--- a/src/storage/interfaces/storage.interface.ts
+++ b/src/storage/interfaces/storage.interface.ts
@@ -5,14 +5,16 @@ export interface StorageInterface {
   setValue(key: string, value: string): Promise<void>;
   delValue(key: string): Promise<void>;
   incrValue(key: string, amount?: number): Promise<void>;
+
   addObject(key: string, value: object): Promise<void>;
   setObject(key: string, value: object): Promise<void>;
   getObject(key: string): Promise<object>;
 
-  sadd(key: string, value: string): Promise<void>;
-  srem(key: string, value: string): Promise<void>;
-  getArray(key: string): Promise<string[]>;
+  addToSet(key: string, value: string): Promise<void>;
+  delFromSet(key: string, value: string): Promise<void>;
+  getSet(key: string): Promise<string[]>;
 
+  // TODO: Too high level
   countTx(type: string, address: string): Promise<number>;
   indexTx(type: string, address: string, transactionId: string, timestamp: number): Promise<void>;
   getTx(type: string, address: string, limit: number, offset: number): Promise<string[]>;

--- a/src/storage/storage.service.spec.ts
+++ b/src/storage/storage.service.spec.ts
@@ -133,24 +133,24 @@ describe('StorageService', () => {
         const addObject = jest.spyOn(redisStorageService, 'addObject').mockImplementation(() => Promise.resolve());
 
         const key = 'C9ED6179884278AF4E0D91286E52B688EF5B6998AF5E33D7E574DA3A719CA3D8';
-        const anchor = '2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE';
+        const hash = '2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE';
 
         const transaction = {
-          anchor,
+          hash,
           id: 'fake_transaction',
           sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
           block: '1',
           position: '10',
         };
 
-        await storageService.saveMappedAnchor(key, transaction.anchor, transaction);
+        await storageService.saveMappedAnchor(key, transaction.hash, transaction);
 
         expect(addToSet.mock.calls.length).toBe(1);
         expect(addToSet.mock.calls[0][0]).toBe(`lto:mapped-anchor:${key.toLowerCase()}`)
-        expect(addToSet.mock.calls[0][1]).toBe(anchor);
+        expect(addToSet.mock.calls[0][1]).toBe(hash);
 
         expect(addObject.mock.calls.length).toBe(1);
-        expect(addObject.mock.calls[0][0]).toBe(`lto:mapped-anchor:${key.toLowerCase()}:${anchor.toLowerCase()}`);
+        expect(addObject.mock.calls[0][0]).toBe(`lto:mapped-anchor:${key.toLowerCase()}:${hash.toLowerCase()}`);
         expect(addObject.mock.calls[0][1]).toEqual(transaction);
       });
     });

--- a/src/storage/storage.service.spec.ts
+++ b/src/storage/storage.service.spec.ts
@@ -7,6 +7,7 @@ import { RedisStorageService } from './types/redis.storage.service';
 import { VerificationMethod } from '../identity/verification-method/model/verification-method.model';
 import { StorageTypeEnum } from '../config/enums/storage.type.enum';
 import { RedisGraphService } from './redis-graph/redis-graph.service';
+import exp = require("constants");
 
 describe('StorageService', () => {
   let module: TestingModule;
@@ -128,21 +129,28 @@ describe('StorageService', () => {
 
     describe('saveMappedAnchor()', () => {
       test('should save the anchor', async () => {
+        const addToSet = jest.spyOn(redisStorageService, 'addToSet').mockImplementation(() => Promise.resolve());
         const addObject = jest.spyOn(redisStorageService, 'addObject').mockImplementation(() => Promise.resolve());
 
         const key = 'C9ED6179884278AF4E0D91286E52B688EF5B6998AF5E33D7E574DA3A719CA3D8';
+        const anchor = '2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE';
 
         const transaction = {
-          anchor: '2C26B46B68FFC68FF99B453C1D30413413422D706483BFA0F98A5E886266E7AE',
+          anchor,
           id: 'fake_transaction',
+          sender: '3NCEKjExpsxzyJpLutF8U9uVDiKu8oStn68',
           block: '1',
           position: '10',
         };
 
-        await storageService.saveMappedAnchor(key, transaction);
+        await storageService.saveMappedAnchor(key, transaction.anchor, transaction);
+
+        expect(addToSet.mock.calls.length).toBe(1);
+        expect(addToSet.mock.calls[0][0]).toBe(`lto:mapped-anchor:${key.toLowerCase()}`)
+        expect(addToSet.mock.calls[0][1]).toBe(anchor);
 
         expect(addObject.mock.calls.length).toBe(1);
-        expect(addObject.mock.calls[0][0]).toBe(`lto:mapped-anchor:${key.toLowerCase()}`);
+        expect(addObject.mock.calls[0][0]).toBe(`lto:mapped-anchor:${key.toLowerCase()}:${anchor.toLowerCase()}`);
         expect(addObject.mock.calls[0][1]).toEqual(transaction);
       });
     });
@@ -153,10 +161,10 @@ describe('StorageService', () => {
             .spyOn(redisStorageService, 'getObject')
             .mockImplementation(() => Promise.resolve({some: 'data'}));
 
-        const result = await storageService.getMappedAnchor('some-anchor');
+        const result = await storageService.getMappedAnchor('some-key', 'some-value');
 
         expect(getObject).toHaveBeenCalledTimes(1);
-        expect(getObject).toHaveBeenCalledWith('lto:mapped-anchor:some-anchor');
+        expect(getObject).toHaveBeenCalledWith('lto:mapped-anchor:some-key:some-value');
         expect(result).toEqual({some: 'data'});
       });
     });
@@ -530,7 +538,7 @@ describe('StorageService', () => {
       describe('saveAssociation()', () => {
         test('should save associations using regular storage', async () => {
           const graphSave = jest.spyOn(redisGraphService, 'saveAssociation').mockImplementation(async () => {});
-          const redisSave = jest.spyOn(redisStorageService, 'sadd').mockImplementation(async () => {});
+          const redisSave = jest.spyOn(redisStorageService, 'addToSet').mockImplementation(async () => {});
 
           const sender = 'some-sender';
           const recipient = 'some-recipient';
@@ -547,7 +555,7 @@ describe('StorageService', () => {
 
       describe('getAssociations()', () => {
         test('should retrieve associations using regular storage', async () => {
-          const redisGet = jest.spyOn(redisStorageService, 'getArray').mockImplementation(async () => []);
+          const redisGet = jest.spyOn(redisStorageService, 'getSet').mockImplementation(async () => []);
           const graphGet = jest.spyOn(redisGraphService, 'getAssociations').mockImplementation(async () => {
             return { children: [], parents: [] };
           });
@@ -568,7 +576,7 @@ describe('StorageService', () => {
 
       describe('removeAssociation()', () => {
         test('should remove associations using regular storage', async () => {
-          const redisRemove = jest.spyOn(redisStorageService, 'srem').mockImplementation(async () => {});
+          const redisRemove = jest.spyOn(redisStorageService, 'delFromSet').mockImplementation(async () => {});
           const graphRemove = jest.spyOn(redisGraphService, 'removeAssociation').mockImplementation(async () => {});
 
           const sender = 'some-sender';
@@ -595,7 +603,7 @@ describe('StorageService', () => {
       describe('saveAssociation()', () => {
         test('should save associations using redis graph', async () => {
           const graphSave = jest.spyOn(redisGraphService, 'saveAssociation').mockImplementation(async () => {});
-          const redisSave = jest.spyOn(redisStorageService, 'sadd').mockImplementation(async () => {});
+          const redisSave = jest.spyOn(redisStorageService, 'addToSet').mockImplementation(async () => {});
 
           const sender = 'some-sender';
           const recipient = 'some-recipient';
@@ -612,7 +620,7 @@ describe('StorageService', () => {
 
       describe('getAssociations()', () => {
         test('should retrieve associations using redis graph', async () => {
-          const redisGet = jest.spyOn(redisStorageService, 'getArray').mockImplementation(async () => []);
+          const redisGet = jest.spyOn(redisStorageService, 'getSet').mockImplementation(async () => []);
           const graphGet = jest.spyOn(redisGraphService, 'getAssociations').mockImplementation(async () => {
             return { children: [], parents: [] };
           });
@@ -632,7 +640,7 @@ describe('StorageService', () => {
 
       describe('removeAssociation()', () => {
         test('should remove associations using redis graph', async () => {
-          const redisRemove = jest.spyOn(redisStorageService, 'srem').mockImplementation(async () => {});
+          const redisRemove = jest.spyOn(redisStorageService, 'delFromSet').mockImplementation(async () => {});
           const graphRemove = jest.spyOn(redisGraphService, 'removeAssociation').mockImplementation(async () => {});
 
           const sender = 'some-sender';

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -58,7 +58,7 @@ export class StorageService implements OnModuleInit, OnModuleDestroy {
   async saveMappedAnchor(key: string, hash: string, info: object): Promise<void> {
     await Promise.all([
       this.storage.addToSet(`lto:mapped-anchor:${key.toLowerCase()}`, hash),
-      this.storage.addObject(`lto:mapped-anchor:${key.toLowerCase()}:${hash.toLowerCase()}`, info)
+      this.storage.addObject(`lto:mapped-anchor:${key.toLowerCase()}:${hash.toLowerCase()}`, info),
     ]);
   }
 

--- a/src/storage/types/leveldb.storage.service.ts
+++ b/src/storage/types/leveldb.storage.service.ts
@@ -68,17 +68,16 @@ export class LeveldbStorageService implements StorageInterface, OnModuleInit, On
     return res ? JSON.parse(res) : {};
   }
 
-  async sadd(key: string, value: string): Promise<void> {
-    // TODO: implement
+  async addToSet(key: string, value: string): Promise<void> {
+    await this.connection.sadd(key, value);
   }
 
-  async srem(key: string, value: string): Promise<void> {
-    // TODO: implement
+  async delFromSet(key: string, value: string): Promise<void> {
+    await this.connection.srem(key, value);
   }
 
-  async getArray<T>(key: string): Promise<T[]> {
-    // TODO: implement
-    return [];
+  async getSet(key: string): Promise<string[]> {
+    return this.connection.sget(key);
   }
 
   async countTx(type: string, address: string): Promise<number> {

--- a/src/storage/types/redis.storage.service.ts
+++ b/src/storage/types/redis.storage.service.ts
@@ -71,17 +71,17 @@ export class RedisStorageService implements StorageInterface, OnModuleInit, OnMo
     await Promise.all(promises);
   }
 
-  async sadd(key: string, value: string): Promise<void> {
+  async addToSet(key: string, value: string): Promise<void> {
     await this.init();
     await this.connection.sadd(key, value);
   }
 
-  async srem(key: string, value: string): Promise<void> {
+  async delFromSet(key: string, value: string): Promise<void> {
     await this.init();
     await this.connection.srem(key, value);
   }
 
-  async getArray(key: string): Promise<string[]> {
+  async getSet(key: string): Promise<string[]> {
     await this.init();
 
     const res = await this.connection.smembers(key);


### PR DESCRIPTION
When verifying anchors, allow specifying who should have anchored the hash. This is required for Ownables.